### PR TITLE
Fix for some ST/UT being improperly labeled as T0

### DIFF
--- a/src/main/java/tomato/gui/security/SecurityFilter.java
+++ b/src/main/java/tomato/gui/security/SecurityFilter.java
@@ -62,6 +62,7 @@ public class SecurityFilter {
             int equipmentId = player.inv[slot];
             ParseEquipment.Equipment equipment = ParseEquipment.getEquipmentById(equipmentId);
             Integer minimumTier = this.minTier.get(slot);
+            boolean isSTUT = equipment.labels.contains("ST") || equipment.labels.contains("UT");
 
             // handle empty gear slots
             if (equipment == null) {
@@ -69,7 +70,8 @@ public class SecurityFilter {
                 continue;
             }
 
-            if (equipment.labels.contains("TIERED") && equipment.tier < minimumTier) {
+            // some ST/UT items have the "TIERED" label also - these SHOULD be mutually exclusive
+            if (equipment.labels.contains("TIERED") && equipment.tier < minimumTier && !isSTUT) {
                 missing.add("Gear below reqs: T" + equipment.tier + " " + Player.equipmentNames[slot]);
             }
         }

--- a/src/main/java/tomato/realmshark/ParseEquipment.java
+++ b/src/main/java/tomato/realmshark/ParseEquipment.java
@@ -80,7 +80,12 @@ public class ParseEquipment {
     public static Boolean isParseItem(Equipment e) {
         final boolean isNonConsumable = e.labels != null && !e.labels.contains("CONSUMABLE");
         final boolean isSTUT = e.labels != null && (e.labels.contains("ST") || e.labels.contains("UT"));
-        final boolean isTieredGear = e.labels != null && (e.labels.contains("T" + e.tier) || (e.labels.contains("ARMOR") && e.labels.contains("T" + (e.tier+1)))); // fix for tiered armor hacked implementation
+
+        // detecting tiered gear requires:
+        //  - tier label
+        //  - armor fix (shifted up)
+        //  - not st/ut (because some ut/st get the T0 label for some reason)
+        final boolean isTieredGear = e.labels != null && (e.labels.contains("T" + e.tier) || (e.labels.contains("ARMOR") && e.labels.contains("T" + (e.tier+1)))) && !isSTUT;
 
         return (isNonConsumable && (isSTUT || isTieredGear));
     }


### PR DESCRIPTION
Added two quick checks to make sure the labels `ST` and `UT` are mutually exclusive to `TIERED` - this will prevent the bug with a few UT/ST items that get picked up by the parser as T0 (even though they're not tiered)