### PR TITLE
Tomato

### DIFF
--- a/src/main/java/tomato/gui/dps/DpsToString.java
+++ b/src/main/java/tomato/gui/dps/DpsToString.java
@@ -39,9 +39,6 @@ public class DpsToString {
      * @return logged dps output as a string.
      */
     public static String stringDmgRealtime(MapInfoPacket map, List<Entity> sortedEntityHitList, ArrayList<NotificationPacket> notifications, Entity player, long totalDungeonPcTime) {
-    public static String stringDmgRealtime(MapInfoPacket map, List<Entity> sortedEntityHitList,
-                                           ArrayList<NotificationPacket> notifications,
-                                           Entity player, long totalDungeonPcTime) {
         StringBuilder sb = new StringBuilder();
 
         if(DpsDisplayOptions.equipmentOption == 3) sb.append("Icons are not visible in live tab. Use \"<\" to see icons.\n\n");
@@ -49,15 +46,20 @@ public class DpsToString {
         if (map != null) {
             sb.append(map.name).append(" ").append(DpsGUI.systemTimeToString(totalDungeonPcTime)).append("\n\n");
         }
+
         ArrayList<Pair<String, Integer>> deaths = new ArrayList<>();
         for (NotificationPacket n : notifications) {
-            String name = n.message.split("\"")[9];
-            int graveIcon = n.pictureType;
-            deaths.add(new Pair<>(name, graveIcon));
+            if (n.message != null) {
+                String[] parts = n.message.split("\"");
+                if (parts.length > 9) {
+                    String name = parts[9];
+                    deaths.add(new Pair<>(name, n.pictureType));
+                }
+            }
         }
+
         for (Entity e : sortedEntityHitList) {
-            if (e.maxHp() <= 0) continue;
-            if (CharacterClass.isPlayerCharacter(e.objectType)) continue;
+            if (e == null || e.maxHp() <= 0 || CharacterClass.isPlayerCharacter(e.objectType)) continue;
             sb.append(display(e, deaths, player)).append("\n");
         }
 
@@ -158,60 +160,45 @@ public class DpsToString {
     }
 
     public static String showInv(int equipmentFilter, Entity owner, Entity entity) {
-        if (equipmentFilter == 0 || owner.getStatName() == null) return "";
+        if (equipmentFilter == 0 || owner == null || owner.getStatName() == null) return "";
 
         HashMap<Integer, Equipment>[] inv = new HashMap[4];
 
         for (int i = 0; i < 4; i++) {
             AtomicInteger tot = new AtomicInteger(0);
-            if (inv[i] == null) inv[i] = new HashMap<>();
             inv[i] = new HashMap<>();
             for (Damage d : entity.getDamageList()) {
                 if (d.owner == null || d.owner.id != owner.id || d.ownerInvntory == null) continue;
 
                 int finalI = i;
-                Equipment equipment = inv[i].computeIfAbsent(d.ownerInvntory[i], id -> new Equipment(id, d.ownerEnchants[finalI], tot));
-                // Convert enchant to String
-                String enchantStr = String.valueOf(d.ownerEnchants[finalI]);
                 Equipment equipment = inv[i].computeIfAbsent(d.ownerInvntory[i],
-                        id -> new Equipment(id, enchantStr, tot));
+                        id -> new Equipment(id, String.valueOf(d.ownerEnchants[finalI]), tot));
                 equipment.add(d.damage);
             }
         }
 
         if (equipmentFilter == 1) {
-            StringBuilder s = new StringBuilder();
-            s.append("[");
             StringBuilder s = new StringBuilder("[");
             for (int i = 0; i < 4; i++) {
-                Equipment max = inv[i].values().stream().max(Comparator.comparingInt(e -> e.dmg)).orElseThrow(NoSuchElementException::new);
                 Equipment max = inv[i].values().stream()
                         .max(Comparator.comparingInt(e -> e.dmg))
                         .orElse(new Equipment(0, "0", new AtomicInteger(0)));
                 if (i != 0) s.append(" / ");
                 s.append(IdToAsset.objectName(max.id));
             }
-            s.append("]");
-            return s.toString();
             return s.append("]").toString();
         } else if (equipmentFilter == 2) {
             StringBuilder s = new StringBuilder();
             for (int i = 0; i < 4; i++) {
-                s.append("\n");
-                Collection<Equipment> list = inv[i].values();
-                s.append("       ");
                 s.append("\n       ");
-                boolean first = true;
                 Collection<Equipment> list = inv[i].values();
+                boolean first = true;
                 for (Equipment e : list) {
-                    if (!first) s.append(" /");
                     if (list.size() > 1) {
                         if (!first) s.append(" /");
                         s.append(String.format(" %.1f%% ", 100f * e.dmg / e.totalDmg.get()));
-                        s.append(IdToAsset.objectName(e.id));
                     } else {
                         s.append(" ");
-                        s.append(IdToAsset.objectName(e.id));
                     }
                     s.append(IdToAsset.objectName(e.id));
                     first = false;
@@ -224,8 +211,9 @@ public class DpsToString {
     }
 
     public static String display(Entity entity, ArrayList<Pair<String, Integer>> deaths, Entity player) {
+        if (entity == null) return "";
+
         StringBuilder sb = new StringBuilder();
-        sb.append(entity.name()).append(" HP: ").append(entity.maxHp()).append(entity.getFightTimerString()).append("\n");
         sb.append(entity.name()).append(" HP: ").append(entity.maxHp())
                 .append(entity.getFightTimerString()).append("\n");
 
@@ -233,21 +221,19 @@ public class DpsToString {
         int counter = 0;
 
         for (Damage dmg : playerDamageList) {
+            if (dmg == null || dmg.owner == null) continue;
+
             boolean highlight = false;
             counter++;
             int filter = Filter.filter(dmg.owner, player);
-            if (Filter.shouldFilter() && filter != 1) {
-                continue;
-            } else if (filter == 2) {
-                highlight = true;
-            }
 
             if (Filter.shouldFilter() && filter != 1) continue;
-            else if (filter == 2) highlight = true;
+            if (filter == 2) highlight = true;
 
             String name = dmg.owner.getStatName();
+            if (name == null) continue;
+
             String extra = "    ";
-            String isMe = (dmg.owner.isUser() && DpsDisplayOptions.showMe) ? " ->" : (highlight ? ">>>" : "   ");
             String isMe = (dmg.owner.isUser() && DpsDisplayOptions.showMe) ? " ->" :
                     (highlight ? ">>>" : "   ");
 
@@ -264,21 +250,21 @@ public class DpsToString {
                 extra = String.format("[Garden Hits:%d Dmg:%d]", dmg.counterHits, dmg.counterDmg);
             }
 
-            for (int id : entity.playerDropped.keySet()) {
-                if (dmg.owner.id == id) {
-                    PlayerRemoved pr = entity.playerDropped.get(id);
-                    boolean dead = isDeadPlayer(name, deaths);
-                    extra += String.format("%s %.2f%% [%s / %s]", dead ? "Died" : "Nexus", ((float) pr.hp / pr.max) * 100, df.format(pr.hp).replaceAll(",", " "), df.format(pr.max).replaceAll(",", " "));
-                    extra += String.format("%s %.2f%% [%s / %s]",
-                            dead ? "Died" : "Nexus",
-                            ((float) pr.hp / pr.max) * 100,
-                            df.format(pr.hp).replaceAll(",", " "),
-                            df.format(pr.max).replaceAll(",", " "));
+            if (entity.playerDropped != null) {
+                for (int id : entity.playerDropped.keySet()) {
+                    if (dmg.owner.id == id) {
+                        PlayerRemoved pr = entity.playerDropped.get(id);
+                        boolean dead = isDeadPlayer(name, deaths);
+                        extra += String.format("%s %.2f%% [%s / %s]",
+                                dead ? "Died" : "Nexus",
+                                ((float) pr.hp / pr.max) * 100,
+                                df.format(pr.hp).replaceAll(",", " "),
+                                df.format(pr.max).replaceAll(",", " "));
+                    }
                 }
             }
 
             String inv = showInv(DpsDisplayOptions.equipmentOption, dmg.owner, entity);
-            sb.append(String.format("%s %3d %10s DMG: %7d %6.3f%% %s %s\n", isMe, counter, name, dmg.damage, pers, extra, inv));
             sb.append(String.format("%s %3d %10s DMG: %7d %6.3f%% %s %s\n",
                     isMe, counter, name, dmg.damage, pers, extra, inv));
         }
@@ -288,15 +274,13 @@ public class DpsToString {
     }
 
     private static boolean isDeadPlayer(String name, ArrayList<Pair<String, Integer>> deaths) {
+        if (name == null || deaths == null) return false;
+
         for (Pair<String, Integer> p : deaths) {
-            if (p.left().equals(name)) {
-                return true;
-            }
-            if (p.left().equals(name)) return true;
+            if (name.equals(p.left())) return true;
         }
         return false;
     }
-}
 
     private static class DataBundle {
         final MapInfoPacket map;

--- a/src/main/java/tomato/gui/dps/DpsToString.java
+++ b/src/main/java/tomato/gui/dps/DpsToString.java
@@ -10,13 +10,24 @@ import util.Pair;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-
 public class DpsToString {
-
     private TomatoData data;
     private static final DecimalFormat df = new DecimalFormat("#,###,###");
+
+    // Batch processing and throttling components
+    private final BlockingQueue<DataBundle> packetQueue = new LinkedBlockingQueue<>();
+    private final ExecutorService processingExecutor = Executors.newSingleThreadExecutor();
+    private volatile String lastDisplayString = "";
+    private long lastUpdateTime = 0;
+    private static final long UPDATE_INTERVAL_MS = 100; // 100ms update interval
+
+    // Data sampling components
+    private static final long SAMPLE_INTERVAL_MS = 50; // Sample every 50ms
+    private long lastSampleTime = 0;
+    private DataBundle lastSampledBundle = null;
 
     public DpsToString(TomatoData data) {
         this.data = data;
@@ -28,6 +39,9 @@ public class DpsToString {
      * @return logged dps output as a string.
      */
     public static String stringDmgRealtime(MapInfoPacket map, List<Entity> sortedEntityHitList, ArrayList<NotificationPacket> notifications, Entity player, long totalDungeonPcTime) {
+    public static String stringDmgRealtime(MapInfoPacket map, List<Entity> sortedEntityHitList,
+                                           ArrayList<NotificationPacket> notifications,
+                                           Entity player, long totalDungeonPcTime) {
         StringBuilder sb = new StringBuilder();
 
         if(DpsDisplayOptions.equipmentOption == 3) sb.append("Icons are not visible in live tab. Use \"<\" to see icons.\n\n");
@@ -50,6 +64,99 @@ public class DpsToString {
         return sb.toString();
     }
 
+    /**
+     * New batch processing entry point with data sampling
+     */
+    public void handleNewData(MapInfoPacket map, List<Entity> sortedEntityHitList,
+                              ArrayList<NotificationPacket> notifications,
+                              Entity player, long totalDungeonPcTime) {
+        long now = System.currentTimeMillis();
+
+        // Only add to queue if it's time for a new sample
+        if (now - lastSampleTime >= SAMPLE_INTERVAL_MS) {
+            lastSampleTime = now;
+            DataBundle newBundle = new DataBundle(map, new ArrayList<>(sortedEntityHitList),
+                    new ArrayList<>(notifications), player, totalDungeonPcTime);
+
+            // Merge with previous sample if needed
+            if (lastSampledBundle != null) {
+                newBundle = mergeBundles(lastSampledBundle, newBundle);
+            }
+
+            packetQueue.add(newBundle);
+            lastSampledBundle = newBundle;
+            processingExecutor.submit(this::processPackets);
+        }
+    }
+
+    public String getCurrentDisplay() {
+        return lastDisplayString;
+    }
+
+    private void processPackets() {
+        try {
+            List<DataBundle> batch = new ArrayList<>();
+            packetQueue.drainTo(batch, 100);
+
+            if (!batch.isEmpty()) {
+                DataBundle aggregated = aggregateBundles(batch);
+
+                long now = System.currentTimeMillis();
+                if (now - lastUpdateTime >= UPDATE_INTERVAL_MS) {
+                    lastUpdateTime = now;
+                    lastDisplayString = stringDmgRealtime(
+                            aggregated.map,
+                            aggregated.sortedEntityHitList,
+                            aggregated.notifications,
+                            aggregated.player,
+                            aggregated.totalDungeonPcTime
+                    );
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private DataBundle aggregateBundles(List<DataBundle> bundles) {
+        MapInfoPacket currentMap = null;
+        List<Entity> currentEntities = new ArrayList<>();
+        ArrayList<NotificationPacket> currentNotifications = new ArrayList<>();
+        Entity currentPlayer = null;
+        long currentTime = 0;
+
+        for (DataBundle bundle : bundles) {
+            if (bundle.map != null) currentMap = bundle.map;
+            currentEntities.addAll(bundle.sortedEntityHitList);
+            currentNotifications.addAll(bundle.notifications);
+            if (bundle.player != null) currentPlayer = bundle.player;
+            currentTime = bundle.totalDungeonPcTime;
+        }
+
+        return new DataBundle(currentMap, currentEntities, currentNotifications, currentPlayer, currentTime);
+    }
+
+    /**
+     * Helper method to merge two data bundles for sampling
+     */
+    private DataBundle mergeBundles(DataBundle oldBundle, DataBundle newBundle) {
+        // For map and player, prefer newer data if available
+        MapInfoPacket map = newBundle.map != null ? newBundle.map : oldBundle.map;
+        Entity player = newBundle.player != null ? newBundle.player : oldBundle.player;
+
+        // For time, use the latest
+        long time = Math.max(newBundle.totalDungeonPcTime, oldBundle.totalDungeonPcTime);
+
+        // For entities and notifications, combine both
+        List<Entity> combinedEntities = new ArrayList<>(oldBundle.sortedEntityHitList);
+        combinedEntities.addAll(newBundle.sortedEntityHitList);
+
+        ArrayList<NotificationPacket> combinedNotifs = new ArrayList<>(oldBundle.notifications);
+        combinedNotifs.addAll(newBundle.notifications);
+
+        return new DataBundle(map, combinedEntities, combinedNotifs, player, time);
+    }
+
     public static String showInv(int equipmentFilter, Entity owner, Entity entity) {
         if (equipmentFilter == 0 || owner.getStatName() == null) return "";
 
@@ -58,11 +165,16 @@ public class DpsToString {
         for (int i = 0; i < 4; i++) {
             AtomicInteger tot = new AtomicInteger(0);
             if (inv[i] == null) inv[i] = new HashMap<>();
+            inv[i] = new HashMap<>();
             for (Damage d : entity.getDamageList()) {
                 if (d.owner == null || d.owner.id != owner.id || d.ownerInvntory == null) continue;
 
                 int finalI = i;
                 Equipment equipment = inv[i].computeIfAbsent(d.ownerInvntory[i], id -> new Equipment(id, d.ownerEnchants[finalI], tot));
+                // Convert enchant to String
+                String enchantStr = String.valueOf(d.ownerEnchants[finalI]);
+                Equipment equipment = inv[i].computeIfAbsent(d.ownerInvntory[i],
+                        id -> new Equipment(id, enchantStr, tot));
                 equipment.add(d.damage);
             }
         }
@@ -70,21 +182,29 @@ public class DpsToString {
         if (equipmentFilter == 1) {
             StringBuilder s = new StringBuilder();
             s.append("[");
+            StringBuilder s = new StringBuilder("[");
             for (int i = 0; i < 4; i++) {
                 Equipment max = inv[i].values().stream().max(Comparator.comparingInt(e -> e.dmg)).orElseThrow(NoSuchElementException::new);
+                Equipment max = inv[i].values().stream()
+                        .max(Comparator.comparingInt(e -> e.dmg))
+                        .orElse(new Equipment(0, "0", new AtomicInteger(0)));
                 if (i != 0) s.append(" / ");
                 s.append(IdToAsset.objectName(max.id));
             }
             s.append("]");
             return s.toString();
+            return s.append("]").toString();
         } else if (equipmentFilter == 2) {
             StringBuilder s = new StringBuilder();
             for (int i = 0; i < 4; i++) {
                 s.append("\n");
                 Collection<Equipment> list = inv[i].values();
                 s.append("       ");
+                s.append("\n       ");
                 boolean first = true;
+                Collection<Equipment> list = inv[i].values();
                 for (Equipment e : list) {
+                    if (!first) s.append(" /");
                     if (list.size() > 1) {
                         if (!first) s.append(" /");
                         s.append(String.format(" %.1f%% ", 100f * e.dmg / e.totalDmg.get()));
@@ -93,6 +213,7 @@ public class DpsToString {
                         s.append(" ");
                         s.append(IdToAsset.objectName(e.id));
                     }
+                    s.append(IdToAsset.objectName(e.id));
                     first = false;
                 }
             }
@@ -105,8 +226,12 @@ public class DpsToString {
     public static String display(Entity entity, ArrayList<Pair<String, Integer>> deaths, Entity player) {
         StringBuilder sb = new StringBuilder();
         sb.append(entity.name()).append(" HP: ").append(entity.maxHp()).append(entity.getFightTimerString()).append("\n");
+        sb.append(entity.name()).append(" HP: ").append(entity.maxHp())
+                .append(entity.getFightTimerString()).append("\n");
+
         List<Damage> playerDamageList = entity.getPlayerDamageList();
         int counter = 0;
+
         for (Damage dmg : playerDamageList) {
             boolean highlight = false;
             counter++;
@@ -116,12 +241,21 @@ public class DpsToString {
             } else if (filter == 2) {
                 highlight = true;
             }
+
+            if (Filter.shouldFilter() && filter != 1) continue;
+            else if (filter == 2) highlight = true;
+
             String name = dmg.owner.getStatName();
             String extra = "    ";
             String isMe = (dmg.owner.isUser() && DpsDisplayOptions.showMe) ? " ->" : (highlight ? ">>>" : "   ");
+            String isMe = (dmg.owner.isUser() && DpsDisplayOptions.showMe) ? " ->" :
+                    (highlight ? ">>>" : "   ");
+
             int index = name.indexOf(',');
             if (index != -1) name = name.substring(0, index);
+
             float pers = ((float) dmg.damage * 100 / (float) entity.maxHp());
+
             if (dmg.oryx3GuardDmg) {
                 extra = String.format("[Guarded Hits:%d Dmg:%d]", dmg.counterHits, dmg.counterDmg);
             } else if (entity.dammahCountered && dmg.chancellorDammahDmg) {
@@ -129,17 +263,27 @@ public class DpsToString {
             } else if (dmg.walledGardenReflectors) {
                 extra = String.format("[Garden Hits:%d Dmg:%d]", dmg.counterHits, dmg.counterDmg);
             }
+
             for (int id : entity.playerDropped.keySet()) {
                 if (dmg.owner.id == id) {
                     PlayerRemoved pr = entity.playerDropped.get(id);
                     boolean dead = isDeadPlayer(name, deaths);
                     extra += String.format("%s %.2f%% [%s / %s]", dead ? "Died" : "Nexus", ((float) pr.hp / pr.max) * 100, df.format(pr.hp).replaceAll(",", " "), df.format(pr.max).replaceAll(",", " "));
+                    extra += String.format("%s %.2f%% [%s / %s]",
+                            dead ? "Died" : "Nexus",
+                            ((float) pr.hp / pr.max) * 100,
+                            df.format(pr.hp).replaceAll(",", " "),
+                            df.format(pr.max).replaceAll(",", " "));
                 }
             }
+
             String inv = showInv(DpsDisplayOptions.equipmentOption, dmg.owner, entity);
             sb.append(String.format("%s %3d %10s DMG: %7d %6.3f%% %s %s\n", isMe, counter, name, dmg.damage, pers, extra, inv));
+            sb.append(String.format("%s %3d %10s DMG: %7d %6.3f%% %s %s\n",
+                    isMe, counter, name, dmg.damage, pers, extra, inv));
         }
         sb.append("\n");
+
         return sb.toString();
     }
 
@@ -148,7 +292,39 @@ public class DpsToString {
             if (p.left().equals(name)) {
                 return true;
             }
+            if (p.left().equals(name)) return true;
         }
         return false;
+    }
+}
+
+    private static class DataBundle {
+        final MapInfoPacket map;
+        final List<Entity> sortedEntityHitList;
+        final ArrayList<NotificationPacket> notifications;
+        final Entity player;
+        final long totalDungeonPcTime;
+
+        DataBundle(MapInfoPacket map, List<Entity> sortedEntityHitList,
+                   ArrayList<NotificationPacket> notifications,
+                   Entity player, long totalDungeonPcTime) {
+            this.map = map;
+            this.sortedEntityHitList = sortedEntityHitList;
+            this.notifications = notifications;
+            this.player = player;
+            this.totalDungeonPcTime = totalDungeonPcTime;
+        }
+    }
+
+    public void shutdown() {
+        processingExecutor.shutdown();
+        try {
+            if (!processingExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+                processingExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            processingExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/java/tomato/gui/dps/IconDpsGUI.java
+++ b/src/main/java/tomato/gui/dps/IconDpsGUI.java
@@ -2,6 +2,15 @@ package tomato.gui.dps;
 
 import assets.IdToAsset;
 import assets.ImageBuffer;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.*;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
 import packets.data.ObjectStatusData;
 import packets.data.StatData;
 import packets.data.enums.StatType;
@@ -13,16 +22,6 @@ import tomato.realmshark.ParseEnchants;
 import tomato.realmshark.enums.CharacterClass;
 import util.Pair;
 
-import javax.swing.*;
-import javax.swing.border.TitledBorder;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.IOException;
-import java.text.DecimalFormat;
-import java.util.*;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class IconDpsGUI extends DisplayDpsGUI {
 
     private static JPanel charPanel;
@@ -31,7 +30,11 @@ public class IconDpsGUI extends DisplayDpsGUI {
     private ArrayList<NotificationPacket> notifications;
     private static final DecimalFormat df = new DecimalFormat("#,###,###");
     private static HashMap<Integer, Image> imgMap = new HashMap<>();
-    private static final BufferedImage ig = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+    private static final BufferedImage ig = new BufferedImage(
+        1,
+        1,
+        BufferedImage.TYPE_INT_ARGB
+    );
 
     public IconDpsGUI(TomatoData data) {
         this.data = data;
@@ -46,17 +49,20 @@ public class IconDpsGUI extends DisplayDpsGUI {
         scroll.getVerticalScrollBar().setUnitIncrement(40);
         new SmartScroller(scroll);
         add(scroll, BorderLayout.CENTER);
-
-//        JButton button = new JButton("String Display");
-//        button.addActionListener(e -> clicked());
-//        add(button, BorderLayout.SOUTH);
+        //        JButton button = new JButton("String Display");
+        //        button.addActionListener(e -> clicked());
+        //        add(button, BorderLayout.SOUTH);
     }
 
-//    private void clicked() {
-//        DpsGUI.setDisplayAsString();
-//    }
+    //    private void clicked() {
+    //        DpsGUI.setDisplayAsString();
+    //    }
 
-    private void updateDps(MapInfoPacket map, List<Entity> sortedEntityHitList, long totalDungeonPcTime) {
+    private void updateDps(
+        MapInfoPacket map,
+        List<Entity> sortedEntityHitList,
+        long totalDungeonPcTime
+    ) {
         ArrayList<Pair<String, Integer>> deaths = new ArrayList<>();
         for (NotificationPacket n : notifications) {
             String name = n.message.split("\"")[9];
@@ -67,13 +73,21 @@ public class IconDpsGUI extends DisplayDpsGUI {
 
         {
             JPanel dungeon = new JPanel();
-            dungeon.setBorder(BorderFactory.createTitledBorder(null, map.name + DpsGUI.systemTimeToString(totalDungeonPcTime), TitledBorder.CENTER, TitledBorder.CENTER, mainFont));
-//            dungeon.setBorder(BorderFactory.createTitledBorder(name));
-//            dungeon.setPreferredSize(new Dimension(320, 24));
+            dungeon.setBorder(
+                BorderFactory.createTitledBorder(
+                    null,
+                    map.name + DpsGUI.systemTimeToString(totalDungeonPcTime),
+                    TitledBorder.CENTER,
+                    TitledBorder.CENTER,
+                    mainFont
+                )
+            );
+            //            dungeon.setBorder(BorderFactory.createTitledBorder(name));
+            //            dungeon.setPreferredSize(new Dimension(320, 24));
             charPanel.add(dungeon);
         }
 
-//        sb.append("Total time in dungeon:").append(DpsGUI.systemTimeToString(totalDungeonPcTime)).append("\n");
+        //        sb.append("Total time in dungeon:").append(DpsGUI.systemTimeToString(totalDungeonPcTime)).append("\n");
         for (Entity e : sortedEntityHitList) {
             if (e.maxHp() <= 0) continue;
             if (CharacterClass.isPlayerCharacter(e.objectType)) continue;
@@ -89,20 +103,37 @@ public class IconDpsGUI extends DisplayDpsGUI {
         repaint();
     }
 
-    private static JPanel createMainBox(Entity entity, ArrayList<Pair<String, Integer>> deaths, Entity player) {
+    private static JPanel createMainBox(
+        Entity entity,
+        ArrayList<Pair<String, Integer>> deaths,
+        Entity player
+    ) {
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
         panel.setBorder(BorderFactory.createEmptyBorder(0, 0, 5, 0));
         JPanel mobPanel = new JPanel();
-        mobPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createMatteBorder(1, 0, 1, 0, Color.GRAY), BorderFactory.createEmptyBorder(0, 0, 0, 0)));
+        mobPanel.setBorder(
+            BorderFactory.createCompoundBorder(
+                BorderFactory.createMatteBorder(1, 0, 1, 0, Color.GRAY),
+                BorderFactory.createEmptyBorder(0, 0, 0, 0)
+            )
+        );
 
         mobPanel.setLayout(new BoxLayout(mobPanel, BoxLayout.X_AXIS));
 
         StringBuilder sb = new StringBuilder();
-        sb.append(entity.name()).append(" HP: ").append(entity.maxHp()).append("\n");
+        sb
+            .append(entity.name())
+            .append(" HP: ")
+            .append(entity.maxHp())
+            .append("\n");
         sb.append(entity.getFightTimerString());
         String mobName = sb.toString();
-        JLabel l = new JLabel(mobName, ImageBuffer.getOutlinedIcon(entity.objectType, 40), JLabel.LEFT);
+        JLabel l = new JLabel(
+            mobName,
+            ImageBuffer.getOutlinedIcon(entity.objectType, 40),
+            JLabel.LEFT
+        );
         int firstHP = getHighestHP(entity);
         l.setToolTipText("Fight start HP: " + firstHP);
         int mobNameStringSize = getStringSize(mobName) + 48;
@@ -116,7 +147,9 @@ public class IconDpsGUI extends DisplayDpsGUI {
         List<Damage> playerDamageList = entity.getPlayerDamageList();
 
         JPanel panelAllPlayers = new JPanel();
-        panelAllPlayers.setLayout(new BoxLayout(panelAllPlayers, BoxLayout.Y_AXIS));
+        panelAllPlayers.setLayout(
+            new BoxLayout(panelAllPlayers, BoxLayout.Y_AXIS)
+        );
         panel.add(panelAllPlayers);
 
         int counter = 0;
@@ -139,22 +172,46 @@ public class IconDpsGUI extends DisplayDpsGUI {
             }
 
             String name = dmg.owner.name();
-            JPanel inv = equipment(DpsDisplayOptions.equipmentOption, dmg.owner, entity);
+            JPanel inv = equipment(
+                DpsDisplayOptions.equipmentOption,
+                dmg.owner,
+                entity
+            );
 
             String extra = "";
             if (dmg.oryx3GuardDmg) {
-                extra = String.format("[Guarded Hits:%d Dmg:%d]", dmg.counterHits, dmg.counterDmg);
+                extra = String.format(
+                    "[Guarded Hits:%d Dmg:%d]",
+                    dmg.counterHits,
+                    dmg.counterDmg
+                );
             } else if (entity.dammahCountered && dmg.chancellorDammahDmg) {
-                extra = String.format("[Dammah Hits:%d Dmg:%d]", dmg.counterHits, dmg.counterDmg);
+                extra = String.format(
+                    "[Dammah Hits:%d Dmg:%d]",
+                    dmg.counterHits,
+                    dmg.counterDmg
+                );
             } else if (dmg.walledGardenReflectors) {
-                extra = String.format("[Garden Hits:%d Dmg:%d]", dmg.counterHits, dmg.counterDmg);
+                extra = String.format(
+                    "[Garden Hits:%d Dmg:%d]",
+                    dmg.counterHits,
+                    dmg.counterDmg
+                );
             }
-            float pers = ((float) dmg.damage * 100 / (float) entity.maxHp());
+            float pers = (((float) dmg.damage * 100) / (float) entity.maxHp());
 
-            String userIndicator = String.format("%s%d", user ? " ->" : (highlight ? ">>" : "  "), counter);
+            String userIndicator = String.format(
+                "%s%d",
+                user ? " ->" : (highlight ? ">>" : "  "),
+                counter
+            );
             String s2 = String.format("DMG: %7d %6.3f%%", dmg.damage, pers);
             int icon = 0;
-            if (dmg.owner != null && dmg.owner.stat != null && dmg.owner.stat.get(StatType.SKIN_ID) != null) {
+            if (
+                dmg.owner != null &&
+                dmg.owner.stat != null &&
+                dmg.owner.stat.get(StatType.SKIN_ID) != null
+            ) {
                 int skinId = dmg.owner.stat.get(StatType.SKIN_ID).statValue;
                 if (skinId != 0) {
                     icon = skinId;
@@ -164,7 +221,11 @@ public class IconDpsGUI extends DisplayDpsGUI {
             } else if (dmg.owner != null) {
                 icon = dmg.owner.objectType;
             }
-            JLabel playerIconLabel = new JLabel(userIndicator, ImageBuffer.getOutlinedIcon(icon, 16), JLabel.LEFT);
+            JLabel playerIconLabel = new JLabel(
+                userIndicator,
+                ImageBuffer.getOutlinedIcon(icon, 16),
+                JLabel.LEFT
+            );
             JLabel nameLabel = new JLabel(name);
             JLabel dpsDataLabel = new JLabel(s2);
             JLabel deathNexusLabel = new JLabel();
@@ -175,14 +236,23 @@ public class IconDpsGUI extends DisplayDpsGUI {
                     if (dead != -1) {
                         try {
                             ImageBuffer.getImage(dead);
-                            deathNexusLabel = new JLabel(ImageBuffer.getOutlinedIcon(dead, 16));
+                            deathNexusLabel = new JLabel(
+                                ImageBuffer.getOutlinedIcon(dead, 16)
+                            );
                         } catch (IOException e) {
                             deathNexusLabel = new JLabel("Died");
                         }
                     } else {
                         deathNexusLabel = new JLabel("Nexus");
                     }
-                    deathNexusLabel.setToolTipText(String.format("%.2f%% [%s / %s]", ((float) pr.hp / pr.max) * 100, df.format(pr.hp).replaceAll(",", " "), df.format(pr.max).replaceAll(",", " ")));
+                    deathNexusLabel.setToolTipText(
+                        String.format(
+                            "%.2f%% [%s / %s]",
+                            ((float) pr.hp / pr.max) * 100,
+                            df.format(pr.hp).replaceAll(",", " "),
+                            df.format(pr.max).replaceAll(",", " ")
+                        )
+                    );
                 }
             }
             JLabel counterLabel = new JLabel(extra);
@@ -225,32 +295,55 @@ public class IconDpsGUI extends DisplayDpsGUI {
             DecimalFormat df = new DecimalFormat("###,###.##");
 
             float guardedDamagePercentage = 0;
-            boolean hasGuardedDamage = dmg.oryx3GuardDmg || (entity.dammahCountered && dmg.chancellorDammahDmg) || dmg.walledGardenReflectors;
+            boolean hasGuardedDamage =
+                dmg.oryx3GuardDmg ||
+                (entity.dammahCountered && dmg.chancellorDammahDmg) ||
+                dmg.walledGardenReflectors;
             if (hasGuardedDamage) {
-                guardedDamagePercentage = (float) dmg.counterDmg / dmg.damage * 100;
+                guardedDamagePercentage =
+                    ((float) dmg.counterDmg / dmg.damage) * 100;
             }
 
             int[] damageFight = dmg.owner.damageTaken(entity);
             int[] damageTotal = dmg.owner.damageTaken(null);
             String tooltipText = "";
             if (damageFight[1] > 0) {
-                tooltipText = String.format("Damage taken: %s (hits: %s)\n", damageFight[0], damageFight[1]);
+                tooltipText = String.format(
+                    "Damage taken: %s (hits: %s)\n",
+                    damageFight[0],
+                    damageFight[1]
+                );
             }
             if (damageTotal[1] > 0) {
-                tooltipText += String.format("Total damage taken: %s (hits: %s)\n\n", damageTotal[0], damageTotal[1]);
+                tooltipText += String.format(
+                    "Total damage taken: %s (hits: %s)\n\n",
+                    damageTotal[0],
+                    damageTotal[1]
+                );
             }
-            tooltipText += String.format("Damage per Minute: %s", df.format(damagePerMinute));
+            tooltipText += String.format(
+                "Damage per Minute: %s",
+                df.format(damagePerMinute)
+            );
             if (hasGuardedDamage) {
-                tooltipText += String.format("\nGuarded Damage: %s%%", df.format(guardedDamagePercentage));
+                tooltipText += String.format(
+                    "\nGuarded Damage: %s%%",
+                    df.format(guardedDamagePercentage)
+                );
             }
-            pp.setToolTipText("<html>" + tooltipText.replace("\n", "<br>") + "</html>");
+            pp.setToolTipText(
+                "<html>" + tooltipText.replace("\n", "<br>") + "</html>"
+            );
 
             panelAllPlayers.add(pp);
         }
         pref[0] = 40;
         for (int i = 0; i < panels.length; i++) {
             for (JPanel p : panels[i]) {
-                Dimension preferredSize = new Dimension(pref[i], pref[pref.length - 1] + 5);
+                Dimension preferredSize = new Dimension(
+                    pref[i],
+                    pref[pref.length - 1] + 5
+                );
                 p.setPreferredSize(preferredSize);
                 p.setMaximumSize(preferredSize);
             }
@@ -283,7 +376,10 @@ public class IconDpsGUI extends DisplayDpsGUI {
         return size;
     }
 
-    private static int isDeadPlayer(String name, ArrayList<Pair<String, Integer>> deaths) {
+    private static int isDeadPlayer(
+        String name,
+        ArrayList<Pair<String, Integer>> deaths
+    ) {
         for (Pair<String, Integer> p : deaths) {
             if (p.left().equals(name)) {
                 return p.right();
@@ -302,7 +398,10 @@ public class IconDpsGUI extends DisplayDpsGUI {
     }
 
     private static boolean filter(String name) {
-        if (!DpsDisplayOptions.nameFilter || DpsDisplayOptions.filteredStrings.length == 0) return false;
+        if (
+            !DpsDisplayOptions.nameFilter ||
+            DpsDisplayOptions.filteredStrings.length == 0
+        ) return false;
         for (String n : DpsDisplayOptions.filteredStrings) {
             if (name.toLowerCase().startsWith(n.toLowerCase())) {
                 return false;
@@ -311,7 +410,11 @@ public class IconDpsGUI extends DisplayDpsGUI {
         return true;
     }
 
-    private static JPanel equipment(int equipmentFilter, Entity owner, Entity entity) {
+    private static JPanel equipment(
+        int equipmentFilter,
+        Entity owner,
+        Entity entity
+    ) {
         JPanel panel = new JPanel();
         panel.setPreferredSize(new Dimension(76, 16));
         panel.setLayout(new GridLayout(1, 4));
@@ -324,19 +427,73 @@ public class IconDpsGUI extends DisplayDpsGUI {
             AtomicInteger tot = new AtomicInteger(0);
             if (inv[i] == null) inv[i] = new HashMap<>();
             for (Damage d : entity.getDamageList()) {
-                if (d.owner == null || d.owner.id != owner.id || d.ownerInvntory == null) continue;
+                if (
+                    d.owner == null ||
+                    d.owner.id != owner.id ||
+                    d.ownerInvntory == null
+                ) continue;
 
                 int finalI = i;
-                Equipment equipment = inv[i].computeIfAbsent(d.ownerInvntory[i], id -> new Equipment(id, d.ownerEnchants[finalI], tot));
+                Equipment equipment =
+                    inv[i].computeIfAbsent(d.ownerInvntory[i], id ->
+                            new Equipment(id, d.ownerEnchants[finalI], tot)
+                        );
                 equipment.add(d.damage);
             }
         }
 
         for (int i = 0; i < 4; i++) {
-            Equipment max = inv[i].values().stream().max(Comparator.comparingInt(e -> e.dmg)).orElseThrow(NoSuchElementException::new);
+            Equipment max =
+                inv[i].values()
+                    .stream()
+                    .max(Comparator.comparingInt(e -> e.dmg))
+                    .orElseThrow(NoSuchElementException::new);
             int eq = max.id;
-            JLabel icon = new JLabel(ImageBuffer.getOutlinedIcon(eq, 16));
-            icon.setToolTipText(String.format("<html>%s<br>%s</html>", IdToAsset.objectName(eq), ParseEnchants.parse(max.enchant)));
+
+            // Get enchant count similar to ParsePanelGUI
+            String parsedEnchant = ParseEnchants.parse(max.enchant);
+            int enchantCount = parsedEnchant.split("\n").length;
+
+            // Apply glow based on enchant count
+            JLabel icon;
+            if (enchantCount == 0) {
+                icon = new JLabel(ImageBuffer.getOutlinedIcon(eq, 16));
+            } else {
+                Color glowColor;
+                switch (enchantCount) {
+                    case 1:
+                        glowColor = new Color(0, 255, 0);
+                        break;
+                    case 2:
+                        glowColor = new Color(0, 200, 255);
+                        break;
+                    case 3:
+                        glowColor = new Color(200, 0, 255);
+                        break;
+                    case 4:
+                        glowColor = new Color(255, 215, 0);
+                        break;
+                    default:
+                        glowColor = Color.BLACK;
+                }
+                int glowSize = 3; // Same as ParsePanelGUI
+                icon = new JLabel(
+                    ImageBuffer.getOutlinedIconWithGlow(
+                        eq,
+                        16,
+                        glowColor,
+                        glowSize
+                    )
+                );
+            }
+
+            icon.setToolTipText(
+                String.format(
+                    "<html>%s<br>%s</html>",
+                    IdToAsset.objectName(eq),
+                    parsedEnchant
+                )
+            );
             panel.add(icon);
         }
 
@@ -344,7 +501,13 @@ public class IconDpsGUI extends DisplayDpsGUI {
     }
 
     @Override
-    protected void renderData(MapInfoPacket map, List<Entity> sortedEntityHitList, ArrayList<NotificationPacket> deathNotifications, long totalDungeonPcTime, boolean isLive) {
+    protected void renderData(
+        MapInfoPacket map,
+        List<Entity> sortedEntityHitList,
+        ArrayList<NotificationPacket> deathNotifications,
+        long totalDungeonPcTime,
+        boolean isLive
+    ) {
         this.notifications = deathNotifications;
         updateDps(map, sortedEntityHitList, totalDungeonPcTime);
         guiUpdate();

--- a/src/main/java/tomato/gui/keypop/KeypopGUI.java
+++ b/src/main/java/tomato/gui/keypop/KeypopGUI.java
@@ -13,15 +13,15 @@ import util.Util;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-//message={"k":"s.dungeon_opened_by","t":{"player":"PLAYERNAME",}}   key pop
-//message={"k":"s.something_by_player","t":{"name":"The Shield Monument has been activated","player":"PLAYERNAME",}}  rune pop
-//message={"k":"s.dungeon_unlocked_by","t":{"name":"The Void","player":"PLAYERNAME",}}   vial pop
-//message={"k":"s.dungeon_unlocked_by","t":{"name":"Wine Cellar","player":"PLAYERNAME",}}   Inc pop
 
 /**
  * GUI class for popping dungeons.
@@ -29,6 +29,9 @@ import java.util.regex.Pattern;
 public class KeypopGUI extends JPanel {
 
     private static JTextArea textAreaKeypop;
+    private static boolean logToFile = false;
+    private static final String LOG_FILE = "keypops.log";
+    private static final SimpleDateFormat logDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     private static final Pattern keypopParse = Pattern.compile("\"player\":\"([^\"]+)\"");
     private static final Pattern nonkeypopParse = Pattern.compile("[^ ]*\"name\":\"([A-Za-z ]*)\",\"player\":\"([A-Za-z]*)[^ ]*");
@@ -39,20 +42,29 @@ public class KeypopGUI extends JPanel {
 
     public KeypopGUI() {
         loadDungeonChoices();
+        loadLoggingPreference();
 
         setLayout(new BorderLayout());
         textAreaKeypop = new JTextArea();
         add(TomatoGUI.createTextArea(textAreaKeypop, false));
 
-        JPanel south = new JPanel(new GridLayout());
+        JPanel south = new JPanel(new GridLayout(1, 3));
         JButton clearButton = new JButton("Clear");
         clearButton.addActionListener(e -> textAreaKeypop.setText(""));
         south.add(clearButton);
 
         JButton notificationButton = new JButton("Notifications");
         notificationButton.addActionListener(e -> showConfigureDialog());
-
         south.add(notificationButton);
+
+        JCheckBox logCheckbox = new JCheckBox("Log to file");
+        logCheckbox.setSelected(logToFile);
+        logCheckbox.addActionListener(e -> {
+            logToFile = logCheckbox.isSelected();
+            saveLoggingPreference();
+        });
+        south.add(logCheckbox);
+
         add(south, BorderLayout.SOUTH);
     }
 
@@ -135,12 +147,33 @@ public class KeypopGUI extends JPanel {
     }
 
     /**
-     * Add text to the key pop text area.
+     * Add text to the key pop text area and optionally log to file.
      *
      * @param s The text to be added at the end of text area.
      */
     public static void appendTextAreaKeypop(String s) {
-        if (textAreaKeypop != null) textAreaKeypop.append(s);
+        if (textAreaKeypop != null) {
+            textAreaKeypop.append(s);
+        }
+
+        if (logToFile) {
+            logToFile(s);
+        }
+    }
+
+    /**
+     * Logs the key pop message to a file with timestamp.
+     *
+     * @param message The message to log
+     */
+    private static void logToFile(String message) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(LOG_FILE, true))) {
+            String timestamp = logDateFormat.format(new Date());
+            writer.write(timestamp + " " + message);
+            writer.newLine();
+        } catch (IOException e) {
+            System.err.println("Error writing to keypop log file: " + e.getMessage());
+        }
     }
 
     /**
@@ -275,5 +308,20 @@ public class KeypopGUI extends JPanel {
             String[] list = keySound.split(",");
             selectedDungeons.addAll(Arrays.asList(list));
         }
+    }
+
+    /**
+     * Loads logging preference from disk
+     */
+    private static void loadLoggingPreference() {
+        String loggingPref = PropertiesManager.getProperty("keypopLogging");
+        logToFile = loggingPref != null && Boolean.parseBoolean(loggingPref);
+    }
+
+    /**
+     * Saves logging preference to disk
+     */
+    private static void saveLoggingPreference() {
+        PropertiesManager.setProperties("keypopLogging", String.valueOf(logToFile));
     }
 }

--- a/src/main/java/tomato/gui/maingui/TomatoMenuBar.java
+++ b/src/main/java/tomato/gui/maingui/TomatoMenuBar.java
@@ -28,7 +28,7 @@ public class TomatoMenuBar implements ActionListener {
     private JRadioButtonMenuItem fontNameMonospaced, fontNameDialog, fontNameDialogInput, fontNameSerif, fontNameSansSerif, fontNameSegoe;
     private JRadioButtonMenuItem dpsEquipmentNone, dpsEquipmentSimple, dpsEquipmentFull, dpsIcon;
     private JRadioButtonMenuItem dpsSortLastHit, dpsSortFirstHit, dpsSortMaxHp, dpsSortFightTimer, dpsSortBossOnly;
-    private JCheckBoxMenuItem fontStyleBold, fontStyleItalic, dpsShowMe, saveChat, chatPing, chatPingGuild, whiteBagSound, chatPingParty, orangeBagSound, redBagSound, goldBagSound, eggBagSound, tradePing, disableDataSending;
+    private JCheckBoxMenuItem fontStyleBold, fontStyleItalic, dpsShowMe, saveChat, chatPing, chatPingGuild, whiteBagSound, chatPingParty, orangeBagSound, redBagSound, goldBagSound, eggBagSound, blueBagSound, tradePing, disableDataSending;
     private JCheckBoxMenuItem filterWhiteBag, filterOrangeBag, filterRedBag, filterGoldBag, filterEggBag, filterBlueBag, filterTealBag, filterPurpleBag, filterPinkBag, filterBrownBag;
     private JSlider soundSlider;
     private JMenu file, edit, info;
@@ -105,6 +105,8 @@ public class TomatoMenuBar implements ActionListener {
         goldBagSound.addActionListener(this);
         eggBagSound = new JCheckBoxMenuItem("Ping Egg Bag");
         eggBagSound.addActionListener(this);
+        blueBagSound = new JCheckBoxMenuItem("Ping Blue Bag");
+        blueBagSound.addActionListener(this);
         tradePing = new JCheckBoxMenuItem("Trade Ping");
         tradePing.addActionListener(this);
 
@@ -124,6 +126,7 @@ public class TomatoMenuBar implements ActionListener {
         sound.add(redBagSound);
         sound.add(goldBagSound);
         sound.add(eggBagSound);
+        sound.add(blueBagSound);
         sound.add(tradePing);
         setSoundCheckbox();
 
@@ -530,6 +533,14 @@ public class TomatoMenuBar implements ActionListener {
             Sound.playEggBagSound = false;
         }
 
+        String blue = PropertiesManager.getProperty("blueBagSound");
+        if (blue != null) {
+            blueBagSound.setSelected(blue.equals("true"));
+            Sound.playBlueBagSound = blue.equals("true");
+        } else {
+            Sound.playBlueBagSound = false;
+        }
+
         String trade = PropertiesManager.getProperty("tradePing");
         if (trade != null) {
             tradePing.setSelected(trade.equals("true"));
@@ -767,6 +778,11 @@ public class TomatoMenuBar implements ActionListener {
             PropertiesManager.setProperties("eggBagSound", b ? "true" : "false");
             Sound.playEggBagSound = b;
             if (b) Sound.eggbag.play();
+        } else if (e.getSource() == blueBagSound) { // blue bag sound
+            boolean b = blueBagSound.isSelected();
+            PropertiesManager.setProperties("blueBagSound", b ? "true" : "false");
+            Sound.playBlueBagSound = b;
+            if (b) Sound.bluebag.play();
         } else if (e.getSource() == tradePing) { // trade sound
             boolean b = tradePing.isSelected();
             PropertiesManager.setProperties("tradePing", b ? "true" : "false");

--- a/src/main/java/tomato/gui/security/ParsePanelGUI.java
+++ b/src/main/java/tomato/gui/security/ParsePanelGUI.java
@@ -439,15 +439,55 @@ public class ParsePanelGUI extends JPanel {
         panel.setPreferredSize(new Dimension(100, 24));
         panel.setMaximumSize(new Dimension(100, 24));
         panel.setLayout(new GridLayout(1, 4));
+
+        // Get enchant info for all items
+        String[] enchants = ParseEnchants.extractEnchants(p.player.playerEntity);
+
         for (int i = 0; i < 4; i++) {
             int eq = p.player.inv[i];
-            p.icon[i] = new JLabel(ImageBuffer.getOutlinedIcon(eq, 20));
+            int enchantCount = getEnchantCount(enchants[i]);
+
+            // Use regular outline for non-enchanted items, glow for enchanted ones
+            ImageIcon icon;
+            if (enchantCount == 0) {
+                icon = ImageBuffer.getOutlinedIcon(eq, 20);
+            } else {
+                Color glowColor = getGlowColor(enchantCount);
+                int glowSize = getGlowSize(enchantCount);
+                icon = ImageBuffer.getOutlinedIconWithGlow(eq, 20, glowColor, glowSize);
+            }
+
+            p.icon[i] = new JLabel(icon);
             p.player.itemName[i] = IdToAsset.objectName(eq);
             panel.add(p.icon[i]);
         }
         p.updateToolTipText();
         mainPanel.add(panel);
         return width;
+    }
+
+    // Count number of enchants in the enchant string
+    private static int getEnchantCount(String enchantString) {
+        if (enchantString == null || enchantString.isEmpty()) {
+            return 0;
+        }
+        // Count the number of newlines in the parsed enchant string
+        return enchantString.split("\n").length;
+    }
+
+    // Determine glow color based on enchant count
+    private static Color getGlowColor(int enchantCount) {
+        switch (enchantCount) {
+            case 1: return new Color(0, 255, 0);
+            case 2: return new Color(0, 200, 255);
+            case 3: return new Color(200, 0, 255);
+            case 4: return new Color(255, 215, 0);
+            default: return Color.BLACK;
+        }
+    }
+
+    private static int getGlowSize(int enchantCount) {
+        return 3;
     }
 
     private static int guildLabel(PlayerBox playerBox, JPanel mainPanel, FontMetrics fm, int y, int width) {
@@ -667,15 +707,18 @@ public class ParsePanelGUI extends JPanel {
 
         public void update() {
             Entity playerEntity = this.player.playerEntity;
-
-            // Only update if equipment has changed
             boolean hasEquipmentChanged = player.updateInv();
             if (!hasEquipmentChanged) return;
 
-            setIcon(0, playerEntity.stat.get(StatType.INVENTORY_0_STAT).statValue);
-            setIcon(1, playerEntity.stat.get(StatType.INVENTORY_1_STAT).statValue);
-            setIcon(2, playerEntity.stat.get(StatType.INVENTORY_2_STAT).statValue);
-            setIcon(3, playerEntity.stat.get(StatType.INVENTORY_3_STAT).statValue);
+            // Get the raw enchant strings first
+            String[] enchantStrings = ParseEnchants.getEnchantStrings(playerEntity);
+
+            // Keep original stat access pattern but pass raw enchant strings
+            setIcon(0, playerEntity.stat.get(StatType.INVENTORY_0_STAT).statValue, enchantStrings[0]);
+            setIcon(1, playerEntity.stat.get(StatType.INVENTORY_1_STAT).statValue, enchantStrings[1]);
+            setIcon(2, playerEntity.stat.get(StatType.INVENTORY_2_STAT).statValue, enchantStrings[2]);
+            setIcon(3, playerEntity.stat.get(StatType.INVENTORY_3_STAT).statValue, enchantStrings[3]);
+
             cruciblePanel.setBackground(playerEntity.isCrucible() ? Color.RED : playerEntity.isSeasonal() ? seasonalColor : Color.WHITE);
             updateToolTipText();
             updatePointsPanel();
@@ -708,13 +751,23 @@ public class ParsePanelGUI extends JPanel {
             return pointsPanel;
         }
 
-        private void setIcon(int i, int eq) {
+        private void setIcon(int i, int eq, String enchant) {
             try {
-                icon[i].setIcon(ImageBuffer.getOutlinedIcon(eq, 20));
-//                icon[i].setToolTipText(String.format("<html>%s<br>%s</html>", IdToAsset.objectName(eq), enchant));
+                String parsedEnchant = ParseEnchants.parse(enchant);
+                int enchantCount = getEnchantCount(parsedEnchant);
+
+                if (enchantCount == 0) {
+                    // Use original outline for non-enchanted items
+                    icon[i].setIcon(ImageBuffer.getOutlinedIcon(eq, 20));
+                } else {
+                    // Enhanced glow for enchanted items
+                    Color glowColor = getGlowColor(enchantCount);
+                    int glowSize = getGlowSize(enchantCount);
+                    icon[i].setIcon(ImageBuffer.getOutlinedIconWithGlow(eq, 20, glowColor, glowSize));
+                }
                 player.itemName[i] = IdToAsset.objectName(eq);
             } catch (Exception e) {
-                System.err.println("Failed to set icon for player " + this.player.playerEntity.name() + " on item slot " + i + " for item ID " + eq);
+                e.printStackTrace();
             }
             INSTANCE.updateUI();
         }

--- a/src/main/java/tomato/gui/security/ParsePanelGUI.java
+++ b/src/main/java/tomato/gui/security/ParsePanelGUI.java
@@ -439,15 +439,57 @@ public class ParsePanelGUI extends JPanel {
         panel.setPreferredSize(new Dimension(100, 24));
         panel.setMaximumSize(new Dimension(100, 24));
         panel.setLayout(new GridLayout(1, 4));
+
+        // Get enchant info for all items
+        String[] enchants = ParseEnchants.extractEnchants(p.player.playerEntity);
+
         for (int i = 0; i < 4; i++) {
             int eq = p.player.inv[i];
-            p.icon[i] = new JLabel(ImageBuffer.getOutlinedIcon(eq, 20));
+            int enchantCount = getEnchantCount(enchants[i]);
+
+            // Use regular outline for non-enchanted items, glow for enchanted ones
+            ImageIcon icon;
+            if (enchantCount == 0) {
+                icon = ImageBuffer.getOutlinedIcon(eq, 20);
+            } else {
+                Color glowColor = getGlowColor(enchantCount);
+                int glowSize = getGlowSize(enchantCount);
+                icon = ImageBuffer.getOutlinedIconWithGlow(eq, 20, glowColor, glowSize);
+            }
+
+            p.icon[i] = new JLabel(icon);
             p.player.itemName[i] = IdToAsset.objectName(eq);
             panel.add(p.icon[i]);
         }
         p.updateToolTipText();
         mainPanel.add(panel);
         return width;
+    }
+
+    // Helper method to count number of enchants in the enchant string
+    private static int getEnchantCount(String enchantString) {
+        if (enchantString == null || enchantString.isEmpty()) {
+            return 0;
+        }
+        // Count the number of newlines in the parsed enchant string
+        return enchantString.split("\n").length;
+    }
+
+    // Helper method to determine glow color based on enchant count
+    private static Color getGlowColor(int enchantCount) {
+        // More vibrant colors with full opacity
+        switch (enchantCount) {
+            case 1: return new Color(0, 255, 0);       // Bright Green
+            case 2: return new Color(0, 200, 255);     // Cyan Blue
+            case 3: return new Color(200, 0, 255);     // Vibrant Purple
+            case 4: return new Color(255, 215, 0);     // Gold
+            default: return Color.BLACK;               // No glow for 0
+        }
+    }
+
+    private static int getGlowSize(int enchantCount) {
+
+        return 3;
     }
 
     private static int guildLabel(PlayerBox playerBox, JPanel mainPanel, FontMetrics fm, int y, int width) {
@@ -667,15 +709,18 @@ public class ParsePanelGUI extends JPanel {
 
         public void update() {
             Entity playerEntity = this.player.playerEntity;
-
-            // Only update if equipment has changed
             boolean hasEquipmentChanged = player.updateInv();
             if (!hasEquipmentChanged) return;
 
-            setIcon(0, playerEntity.stat.get(StatType.INVENTORY_0_STAT).statValue);
-            setIcon(1, playerEntity.stat.get(StatType.INVENTORY_1_STAT).statValue);
-            setIcon(2, playerEntity.stat.get(StatType.INVENTORY_2_STAT).statValue);
-            setIcon(3, playerEntity.stat.get(StatType.INVENTORY_3_STAT).statValue);
+            // Get the raw enchant strings first
+            String[] enchantStrings = ParseEnchants.getEnchantStrings(playerEntity);
+
+            // Keep original stat access pattern but pass raw enchant strings
+            setIcon(0, playerEntity.stat.get(StatType.INVENTORY_0_STAT).statValue, enchantStrings[0]);
+            setIcon(1, playerEntity.stat.get(StatType.INVENTORY_1_STAT).statValue, enchantStrings[1]);
+            setIcon(2, playerEntity.stat.get(StatType.INVENTORY_2_STAT).statValue, enchantStrings[2]);
+            setIcon(3, playerEntity.stat.get(StatType.INVENTORY_3_STAT).statValue, enchantStrings[3]);
+
             cruciblePanel.setBackground(playerEntity.isCrucible() ? Color.RED : playerEntity.isSeasonal() ? seasonalColor : Color.WHITE);
             updateToolTipText();
             updatePointsPanel();
@@ -708,13 +753,23 @@ public class ParsePanelGUI extends JPanel {
             return pointsPanel;
         }
 
-        private void setIcon(int i, int eq) {
+        private void setIcon(int i, int eq, String enchant) {
             try {
-                icon[i].setIcon(ImageBuffer.getOutlinedIcon(eq, 20));
-//                icon[i].setToolTipText(String.format("<html>%s<br>%s</html>", IdToAsset.objectName(eq), enchant));
+                String parsedEnchant = ParseEnchants.parse(enchant);
+                int enchantCount = getEnchantCount(parsedEnchant);
+
+                if (enchantCount == 0) {
+                    // Use original outline for non-enchanted items
+                    icon[i].setIcon(ImageBuffer.getOutlinedIcon(eq, 20));
+                } else {
+                    // Enhanced glow for enchanted items
+                    Color glowColor = getGlowColor(enchantCount);
+                    int glowSize = getGlowSize(enchantCount);
+                    icon[i].setIcon(ImageBuffer.getOutlinedIconWithGlow(eq, 20, glowColor, glowSize));
+                }
                 player.itemName[i] = IdToAsset.objectName(eq);
             } catch (Exception e) {
-                System.err.println("Failed to set icon for player " + this.player.playerEntity.name() + " on item slot " + i + " for item ID " + eq);
+                e.printStackTrace();
             }
             INSTANCE.updateUI();
         }

--- a/src/main/java/tomato/gui/security/ParsePanelGUI.java
+++ b/src/main/java/tomato/gui/security/ParsePanelGUI.java
@@ -439,57 +439,15 @@ public class ParsePanelGUI extends JPanel {
         panel.setPreferredSize(new Dimension(100, 24));
         panel.setMaximumSize(new Dimension(100, 24));
         panel.setLayout(new GridLayout(1, 4));
-
-        // Get enchant info for all items
-        String[] enchants = ParseEnchants.extractEnchants(p.player.playerEntity);
-
         for (int i = 0; i < 4; i++) {
             int eq = p.player.inv[i];
-            int enchantCount = getEnchantCount(enchants[i]);
-
-            // Use regular outline for non-enchanted items, glow for enchanted ones
-            ImageIcon icon;
-            if (enchantCount == 0) {
-                icon = ImageBuffer.getOutlinedIcon(eq, 20);
-            } else {
-                Color glowColor = getGlowColor(enchantCount);
-                int glowSize = getGlowSize(enchantCount);
-                icon = ImageBuffer.getOutlinedIconWithGlow(eq, 20, glowColor, glowSize);
-            }
-
-            p.icon[i] = new JLabel(icon);
+            p.icon[i] = new JLabel(ImageBuffer.getOutlinedIcon(eq, 20));
             p.player.itemName[i] = IdToAsset.objectName(eq);
             panel.add(p.icon[i]);
         }
         p.updateToolTipText();
         mainPanel.add(panel);
         return width;
-    }
-
-    // Helper method to count number of enchants in the enchant string
-    private static int getEnchantCount(String enchantString) {
-        if (enchantString == null || enchantString.isEmpty()) {
-            return 0;
-        }
-        // Count the number of newlines in the parsed enchant string
-        return enchantString.split("\n").length;
-    }
-
-    // Helper method to determine glow color based on enchant count
-    private static Color getGlowColor(int enchantCount) {
-        // More vibrant colors with full opacity
-        switch (enchantCount) {
-            case 1: return new Color(0, 255, 0);       // Bright Green
-            case 2: return new Color(0, 200, 255);     // Cyan Blue
-            case 3: return new Color(200, 0, 255);     // Vibrant Purple
-            case 4: return new Color(255, 215, 0);     // Gold
-            default: return Color.BLACK;               // No glow for 0
-        }
-    }
-
-    private static int getGlowSize(int enchantCount) {
-
-        return 3;
     }
 
     private static int guildLabel(PlayerBox playerBox, JPanel mainPanel, FontMetrics fm, int y, int width) {
@@ -709,18 +667,15 @@ public class ParsePanelGUI extends JPanel {
 
         public void update() {
             Entity playerEntity = this.player.playerEntity;
+
+            // Only update if equipment has changed
             boolean hasEquipmentChanged = player.updateInv();
             if (!hasEquipmentChanged) return;
 
-            // Get the raw enchant strings first
-            String[] enchantStrings = ParseEnchants.getEnchantStrings(playerEntity);
-
-            // Keep original stat access pattern but pass raw enchant strings
-            setIcon(0, playerEntity.stat.get(StatType.INVENTORY_0_STAT).statValue, enchantStrings[0]);
-            setIcon(1, playerEntity.stat.get(StatType.INVENTORY_1_STAT).statValue, enchantStrings[1]);
-            setIcon(2, playerEntity.stat.get(StatType.INVENTORY_2_STAT).statValue, enchantStrings[2]);
-            setIcon(3, playerEntity.stat.get(StatType.INVENTORY_3_STAT).statValue, enchantStrings[3]);
-
+            setIcon(0, playerEntity.stat.get(StatType.INVENTORY_0_STAT).statValue);
+            setIcon(1, playerEntity.stat.get(StatType.INVENTORY_1_STAT).statValue);
+            setIcon(2, playerEntity.stat.get(StatType.INVENTORY_2_STAT).statValue);
+            setIcon(3, playerEntity.stat.get(StatType.INVENTORY_3_STAT).statValue);
             cruciblePanel.setBackground(playerEntity.isCrucible() ? Color.RED : playerEntity.isSeasonal() ? seasonalColor : Color.WHITE);
             updateToolTipText();
             updatePointsPanel();
@@ -753,23 +708,13 @@ public class ParsePanelGUI extends JPanel {
             return pointsPanel;
         }
 
-        private void setIcon(int i, int eq, String enchant) {
+        private void setIcon(int i, int eq) {
             try {
-                String parsedEnchant = ParseEnchants.parse(enchant);
-                int enchantCount = getEnchantCount(parsedEnchant);
-
-                if (enchantCount == 0) {
-                    // Use original outline for non-enchanted items
-                    icon[i].setIcon(ImageBuffer.getOutlinedIcon(eq, 20));
-                } else {
-                    // Enhanced glow for enchanted items
-                    Color glowColor = getGlowColor(enchantCount);
-                    int glowSize = getGlowSize(enchantCount);
-                    icon[i].setIcon(ImageBuffer.getOutlinedIconWithGlow(eq, 20, glowColor, glowSize));
-                }
+                icon[i].setIcon(ImageBuffer.getOutlinedIcon(eq, 20));
+//                icon[i].setToolTipText(String.format("<html>%s<br>%s</html>", IdToAsset.objectName(eq), enchant));
                 player.itemName[i] = IdToAsset.objectName(eq);
             } catch (Exception e) {
-                e.printStackTrace();
+                System.err.println("Failed to set icon for player " + this.player.playerEntity.name() + " on item slot " + i + " for item ID " + eq);
             }
             INSTANCE.updateUI();
         }

--- a/src/main/java/tomato/gui/security/ParsePanelGUI.java
+++ b/src/main/java/tomato/gui/security/ParsePanelGUI.java
@@ -10,16 +10,20 @@ import util.PropertiesManager;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.net.URI;
+import java.util.*;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.TreeMap;
+import java.util.List;
 
 public class ParsePanelGUI extends JPanel {
 
@@ -92,10 +96,34 @@ public class ParsePanelGUI extends JPanel {
 
         JButton buttonLeft = new JButton("Copy names to Clipboard");
         JButton buttonRight = new JButton("Copy all to Clipboard");
-        buttonLeft.addActionListener(e -> clicked(false));
-        buttonRight.addActionListener(e -> clicked(true));
         buttons.add(buttonLeft);
         buttons.add(buttonRight);
+        buttonLeft.setToolTipText("<html>Click: Copy names to clipboard<br>Shift+Click: Export names as text file</html>");
+        buttonRight.setToolTipText("<html>Click: Copy all to clipboard<br>Shift+Click: Export as JSON file</html>");
+
+        buttonLeft.addMouseListener(new MouseAdapter() {
+            public void mouseClicked(MouseEvent e) {
+                if ((e.getModifiers() & InputEvent.SHIFT_MASK) != 0) {
+                    // Shift+click - save names to file
+                    saveNamesAsText();
+                } else {
+                    // Normal click - copy to clipboard
+                    clicked(false);
+                }
+            }
+        });
+
+        buttonRight.addMouseListener(new MouseAdapter() {
+            public void mouseClicked(MouseEvent e) {
+                if ((e.getModifiers() & InputEvent.SHIFT_MASK) != 0) {
+                    // Shift+click - save as JSON
+                    saveAsJson(getFilteredPlayers());
+                } else {
+                    // Normal click - copy to clipboard
+                    clicked(true);
+                }
+            }
+        });
 
         // Add Sort checkbox to the buttons panel
         String stateSortCheckBox = PropertiesManager.getProperty("sortCheckBox");
@@ -172,45 +200,137 @@ public class ParsePanelGUI extends JPanel {
     }
 
     private void clicked(boolean full) {
-        // determine who's in scope to be copied
-        boolean onlyUnderReqs = copyOnlyUnderReqCheckbox.isSelected();
-
+        List<Player> players = getFilteredPlayers();
         StringBuilder sb = new StringBuilder();
-        if (full) sb.append("[\n");
-        boolean first = true;
-        int counter = 1;
-        int totalItems = playerDisplay.size();
 
-        for (PlayerBox playerBox : playerDisplay.values()) {
-            Player player = playerBox.player;
-
-            // we don't check if player meets filter criteria under default filter
-            if (currentFilter != null) {
-                // apply under reqs filter
-                if (onlyUnderReqs && !currentFilter.parsePlayer(player).isUnderReqs) continue;
-            }
-
-            if (full) {
-                if (!first) {
-                    sb.append(",").append("\n");
+        if (full) {
+            sb.append("[\n");
+            for (int i = 0; i < players.size(); i++) {
+                sb.append(players.get(i).toString());
+                if (i < players.size() - 1) {
+                    sb.append(",\n");
                 }
-                first = false;
-                sb.append(player);
-            } else {
-                sb.append(player.playerEntity.name());
-                if (counter != totalItems) sb.append(" ");
             }
-
-            counter++;
+            sb.append("\n]");
+        } else {
+            for (int i = 0; i < players.size(); i++) {
+                sb.append(players.get(i).playerEntity.name());
+                if (i < players.size() - 1) {
+                    sb.append(" ");
+                }
+            }
         }
-        if (full) sb.append("\n").append("]");
-        copyToClipboard(String.valueOf(sb));
+
+        copyToClipboard(sb.toString());
     }
 
     private static void copyToClipboard(String s) {
         StringSelection stringSelection = new StringSelection(s);
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(stringSelection, null);
+    }
+
+    private List<Player> getFilteredPlayers() {
+        List<Player> players = new ArrayList<>();
+        boolean onlyUnderReqs = copyOnlyUnderReqCheckbox.isSelected();
+
+        for (PlayerBox playerBox : playerDisplay.values()) {
+            Player player = playerBox.player;
+
+            if (currentFilter != null && onlyUnderReqs && !currentFilter.parsePlayer(player).isUnderReqs) {
+                continue;
+            }
+
+            players.add(player);
+        }
+
+        return players;
+    }
+
+    // Method to save names as text
+    private void saveNamesAsText() {
+        List<Player> players = getFilteredPlayers();
+        StringBuilder sb = new StringBuilder();
+
+        for (Player player : players) {
+            sb.append(player.playerEntity.name()).append("\n");
+        }
+
+        saveToFile(sb.toString(), "ExportNames", ".txt");
+    }
+
+    // Method to save as JSON
+    private void saveAsJson(List<Player> players) {
+        StringBuilder sb = new StringBuilder("[\n");
+
+        for (int i = 0; i < players.size(); i++) {
+            sb.append(players.get(i).toString());
+            if (i < players.size() - 1) {
+                sb.append(",\n");
+            }
+        }
+        sb.append("\n]");
+
+        saveToFile(sb.toString(), "Export", ".json");
+    }
+
+    // Common file saving method
+    private void saveToFile(String content, String prefix, String extension) {
+        try {
+            // Create exports directory if needed
+            File directory = new File("exports");
+            if (!directory.exists()) {
+                directory.mkdir();
+            }
+
+            // Generate filename with timestamp
+            SimpleDateFormat dateFormat = new SimpleDateFormat("MMddyyyy_HHmmss");
+            String dateTimeString = dateFormat.format(new Date());
+            String filename = "exports/" + prefix + dateTimeString + extension;
+            File file = new File(filename);
+
+            // Write content to file
+            try (FileWriter writer = new FileWriter(file)) {
+                writer.write(content);
+                writer.flush();
+            }
+
+            // Copy the FILE OBJECT to clipboard (not just path/contents)
+            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            clipboard.setContents(
+                    new Transferable() {
+                        public DataFlavor[] getTransferDataFlavors() {
+                            return new DataFlavor[]{DataFlavor.javaFileListFlavor};
+                        }
+
+                        public boolean isDataFlavorSupported(DataFlavor flavor) {
+                            return flavor.equals(DataFlavor.javaFileListFlavor);
+                        }
+
+                        public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
+                            if (!isDataFlavorSupported(flavor)) {
+                                throw new UnsupportedFlavorException(flavor);
+                            }
+                            return Collections.singletonList(file);
+                        }
+                    },
+                    null
+            );
+
+            // Show success message
+            JOptionPane.showMessageDialog(this,
+                    "Successfully exported data to:\n" + file.getAbsolutePath() +
+                            "\n\n(File object copied to clipboard - ready to paste)",
+                    "Export Successful",
+                    JOptionPane.INFORMATION_MESSAGE);
+
+        } catch (IOException e) {
+            JOptionPane.showMessageDialog(this,
+                    "Failed to export data:\n" + e.getMessage(),
+                    "Export Failed",
+                    JOptionPane.ERROR_MESSAGE);
+            e.printStackTrace();
+        }
     }
 
     private void guiUpdate() {

--- a/src/main/java/tomato/gui/stats/LootGUI.java
+++ b/src/main/java/tomato/gui/stats/LootGUI.java
@@ -316,7 +316,6 @@ public class LootGUI extends JPanel {
 
     private static int displayBagLootIcons(Entity entity, JPanel mainPanel, int width) {
         JPanel panel = new JPanel();
-//            panel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
         width += 200;
 
         panel.setPreferredSize(new Dimension(200, 24));
@@ -335,16 +334,53 @@ public class LootGUI extends JPanel {
                 JPanel comp = new JPanel();
                 comp.setMinimumSize(new Dimension(24, 24));
                 panel.add(comp);
+                continue;
             }
-            assert sd != null;
             int statValue = sd.statValue;
-            JLabel icon = new JLabel(ImageBuffer.getOutlinedIcon(statValue, 20));
             String itemName = IdToAsset.objectName(statValue);
+            String enchantText = "";
+            int enchantCount = 0;
+
             if (enchants != null && i < enchants.length && !enchants[i].isEmpty() && !enchants[i].equals("AAIE_f_9__3__f8=")) {
-                String e = ParseEnchants.parse(enchants[i]);
-                if (!e.isEmpty()) {
-                    itemName += "<br>" + e;
+                enchantText = ParseEnchants.parse(enchants[i]);
+                if (!enchantText.isEmpty()) {
+                    enchantCount = enchantText.split("\n").length;
                 }
+            }
+
+            /* enchantCount Debug: Print enchantCount and itemName
+            System.out.println(
+                "Item: " + itemName + " | EnchantCount: " + enchantCount
+            );*/
+
+            JLabel icon;
+            if (enchantCount == 0) {
+                icon = new JLabel(ImageBuffer.getOutlinedIcon(statValue, 20));
+            } else {
+                Color glowColor;
+                switch (enchantCount) {
+                    case 1:
+                        glowColor = new Color(0, 255, 0); // Green
+                        break;
+                    case 2:
+                        glowColor = new Color(0, 200, 255); // Blue
+                        break;
+                    case 3:
+                        glowColor = new Color(200, 0, 255); // Purple
+                        break;
+                    case 4:
+                        glowColor = new Color(255, 215, 0); // Gold
+                        break;
+                    default:
+                        glowColor = Color.BLACK;
+                }
+                int glowSize = 3;
+                icon = new JLabel(
+                        ImageBuffer.getOutlinedIconWithGlow(statValue,20, glowColor, glowSize));
+            }
+
+            if (!enchantText.isEmpty()) {
+                itemName += "<br>" + enchantText;
             }
             icon.setToolTipText("<html>" + itemName + "</html>");
             panel.add(icon);

--- a/src/main/java/tomato/gui/stats/LootGUI.java
+++ b/src/main/java/tomato/gui/stats/LootGUI.java
@@ -88,6 +88,7 @@ public class LootGUI extends JPanel {
         if (Sound.playRedBagSound && isRedBag(bag)) Sound.redbag.play();
         if (Sound.playGoldBagSound && isGoldBag(bag)) Sound.goldbag.play();
         if (Sound.playRedBagSound && isEggBag(bag)) Sound.redbag.play();
+        if (Sound.playBlueBagSound && isBlueBag(bag)) Sound.bluebag.play();
 
         if (!disableLootSharing) {
             SendLoot.sendLoot(data, map, bag, dropper, player, time);

--- a/src/main/java/tomato/gui/stats/LootGUI.java
+++ b/src/main/java/tomato/gui/stats/LootGUI.java
@@ -2,6 +2,10 @@ package tomato.gui.stats;
 
 import assets.IdToAsset;
 import assets.ImageBuffer;
+import java.awt.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import javax.swing.*;
 import packets.data.StatData;
 import packets.data.enums.StatType;
 import packets.incoming.MapInfoPacket;
@@ -13,13 +17,7 @@ import tomato.realmshark.*;
 import tomato.realmshark.enums.CharacterStatistics;
 import tomato.realmshark.enums.LootBags;
 
-import javax.swing.*;
-import java.awt.*;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
 public class LootGUI extends JPanel {
-
 
     private static LootGUI INSTANCE;
 
@@ -42,7 +40,6 @@ public class LootGUI extends JPanel {
     public static boolean filterPinkBag = false;
     public static boolean filterBrownBag = false;
 
-
     public LootGUI(TomatoData data) {
         LootGUI.data = data;
         lootDrops = 0;
@@ -62,7 +59,13 @@ public class LootGUI extends JPanel {
         add(scroll, BorderLayout.CENTER);
     }
 
-    public static void update(MapInfoPacket map, Entity bag, Entity dropper, Entity player, long time) {
+    public static void update(
+        MapInfoPacket map,
+        Entity bag,
+        Entity dropper,
+        Entity player,
+        long time
+    ) {
         INSTANCE.updateGui(map, bag, dropper, player, time);
     }
 
@@ -75,7 +78,13 @@ public class LootGUI extends JPanel {
         }
     }
 
-    private void updateGui(MapInfoPacket map, Entity bag, Entity dropper, Entity player, long time) {
+    private void updateGui(
+        MapInfoPacket map,
+        Entity bag,
+        Entity dropper,
+        Entity player,
+        long time
+    ) {
         if (player == null || !update) return;
 
         JPanel panel = createMainBox(map, bag, dropper, player, time);
@@ -84,7 +93,9 @@ public class LootGUI extends JPanel {
         panel.setVisible(isBagVisible(bag));
 
         if (Sound.playWhiteBagSound && isWhiteBag(bag)) Sound.whitebag.play();
-        if (Sound.playOrangeBagSound && isOrangeBag(bag)) Sound.orangebag.play();
+        if (
+            Sound.playOrangeBagSound && isOrangeBag(bag)
+        ) Sound.orangebag.play();
         if (Sound.playRedBagSound && isRedBag(bag)) Sound.redbag.play();
         if (Sound.playGoldBagSound && isGoldBag(bag)) Sound.goldbag.play();
         if (Sound.playRedBagSound && isEggBag(bag)) Sound.redbag.play();
@@ -128,37 +139,53 @@ public class LootGUI extends JPanel {
 
     private boolean isBrownBag(Entity bag) {
         int id = bag.objectType;
-        return id == LootBags.BROWN.getId() || id == LootBags.BOOSTED_BROWN.getId();
+        return (
+            id == LootBags.BROWN.getId() || id == LootBags.BOOSTED_BROWN.getId()
+        );
     }
 
     private boolean isPinkBag(Entity bag) {
         int id = bag.objectType;
-        return id == LootBags.PINK.getId() || id == LootBags.BOOSTED_PINK.getId();
+        return (
+            id == LootBags.PINK.getId() || id == LootBags.BOOSTED_PINK.getId()
+        );
     }
 
     private boolean isPurpleBag(Entity bag) {
         int id = bag.objectType;
-        return id == LootBags.PURPLE.getId() || id == LootBags.BOOSTED_PURPLE.getId();
+        return (
+            id == LootBags.PURPLE.getId() ||
+            id == LootBags.BOOSTED_PURPLE.getId()
+        );
     }
 
     private boolean isTealBag(Entity bag) {
         int id = bag.objectType;
-        return id == LootBags.TEAL.getId() || id == LootBags.BOOSTED_TEAL.getId();
+        return (
+            id == LootBags.TEAL.getId() || id == LootBags.BOOSTED_TEAL.getId()
+        );
     }
 
     private boolean isBlueBag(Entity bag) {
         int id = bag.objectType;
-        return id == LootBags.BLUE.getId() || id == LootBags.BOOSTED_BLUE.getId();
+        return (
+            id == LootBags.BLUE.getId() || id == LootBags.BOOSTED_BLUE.getId()
+        );
     }
 
     private boolean isWhiteBag(Entity bag) {
         int id = bag.objectType;
-        return id == LootBags.WHITE.getId() || id == LootBags.BOOSTED_WHITE.getId();
+        return (
+            id == LootBags.WHITE.getId() || id == LootBags.BOOSTED_WHITE.getId()
+        );
     }
 
     private boolean isOrangeBag(Entity bag) {
         int id = bag.objectType;
-        return id == LootBags.ORANGE.getId() || id == LootBags.BOOSTED_ORANGE.getId();
+        return (
+            id == LootBags.ORANGE.getId() ||
+            id == LootBags.BOOSTED_ORANGE.getId()
+        );
     }
 
     private boolean isRedBag(Entity bag) {
@@ -168,7 +195,9 @@ public class LootGUI extends JPanel {
 
     private boolean isGoldBag(Entity bag) {
         int id = bag.objectType;
-        return id == LootBags.GOLD.getId() || id == LootBags.BOOSTED_GOLD.getId();
+        return (
+            id == LootBags.GOLD.getId() || id == LootBags.BOOSTED_GOLD.getId()
+        );
     }
 
     private boolean isEggBag(Entity bag) {
@@ -181,9 +210,20 @@ public class LootGUI extends JPanel {
         repaint();
     }
 
-    private static JPanel createMainBox(MapInfoPacket map, Entity bag, Entity dropper, Entity player, long time) {
+    private static JPanel createMainBox(
+        MapInfoPacket map,
+        Entity bag,
+        Entity dropper,
+        Entity player,
+        long time
+    ) {
         JPanel mainPanel = new JPanel();
-        mainPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, Color.gray), BorderFactory.createEmptyBorder(0, 20, 0, 20)));
+        mainPanel.setBorder(
+            BorderFactory.createCompoundBorder(
+                BorderFactory.createMatteBorder(0, 0, 1, 0, Color.gray),
+                BorderFactory.createEmptyBorder(0, 20, 0, 20)
+            )
+        );
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.X_AXIS));
 
         mainPanel.putClientProperty("bagEntity", bag); // Store the bag entity for filtering
@@ -203,7 +243,16 @@ public class LootGUI extends JPanel {
         mainPanel.add(Box.createHorizontalStrut(10));
         width = displayTime(mainPanel, width);
         mainPanel.add(Box.createHorizontalStrut(10));
-        width = displayBagDungMob(map, bag, player, dropper, mainPanel, width, exaltBonus, lootTime);
+        width = displayBagDungMob(
+            map,
+            bag,
+            player,
+            dropper,
+            mainPanel,
+            width,
+            exaltBonus,
+            lootTime
+        );
         mainPanel.add(Box.createHorizontalStrut(30));
         width = displayBagLootIcons(bag, mainPanel, width);
 
@@ -214,7 +263,16 @@ public class LootGUI extends JPanel {
         return mainPanel;
     }
 
-    private static int displayBagDungMob(MapInfoPacket map, Entity entity, Entity player, Entity dropper, JPanel mainPanel, int width, int exaltBonus, long lootTime) {
+    private static int displayBagDungMob(
+        MapInfoPacket map,
+        Entity entity,
+        Entity player,
+        Entity dropper,
+        JPanel mainPanel,
+        int width,
+        int exaltBonus,
+        long lootTime
+    ) {
         JPanel panel = new JPanel();
         width += 100;
 
@@ -284,7 +342,12 @@ public class LootGUI extends JPanel {
         return width;
     }
 
-    private static void displayPlayerIcon(MapInfoPacket map, Entity player, int exaltBonus, JPanel panel) {
+    private static void displayPlayerIcon(
+        MapInfoPacket map,
+        Entity player,
+        int exaltBonus,
+        JPanel panel
+    ) {
         int picon = 100;
         boolean isSeasonal = false;
         String name = "Unknown";
@@ -314,9 +377,12 @@ public class LootGUI extends JPanel {
         panel.add(icon);
     }
 
-    private static int displayBagLootIcons(Entity entity, JPanel mainPanel, int width) {
+    private static int displayBagLootIcons(
+        Entity entity,
+        JPanel mainPanel,
+        int width
+    ) {
         JPanel panel = new JPanel();
-//            panel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
         width += 200;
 
         panel.setPreferredSize(new Dimension(200, 24));
@@ -335,16 +401,64 @@ public class LootGUI extends JPanel {
                 JPanel comp = new JPanel();
                 comp.setMinimumSize(new Dimension(24, 24));
                 panel.add(comp);
+                continue;
             }
-            assert sd != null;
             int statValue = sd.statValue;
-            JLabel icon = new JLabel(ImageBuffer.getOutlinedIcon(statValue, 20));
             String itemName = IdToAsset.objectName(statValue);
-            if (enchants != null && i < enchants.length && !enchants[i].isEmpty() && !enchants[i].equals("AAIE_f_9__3__f8=")) {
-                String e = ParseEnchants.parse(enchants[i]);
-                if (!e.isEmpty()) {
-                    itemName += "<br>" + e;
+            String enchantText = "";
+            int enchantCount = 0;
+
+            if (
+                enchants != null &&
+                i < enchants.length &&
+                !enchants[i].isEmpty() &&
+                !enchants[i].equals("AAIE_f_9__3__f8=")
+            ) {
+                enchantText = ParseEnchants.parse(enchants[i]);
+                if (!enchantText.isEmpty()) {
+                    enchantCount = enchantText.split("\n").length;
                 }
+            }
+
+            /* enchantCount Debug: Print enchantCount and itemName
+            System.out.println(
+                "Item: " + itemName + " | EnchantCount: " + enchantCount
+            );*/
+
+            JLabel icon;
+            if (enchantCount == 0) {
+                icon = new JLabel(ImageBuffer.getOutlinedIcon(statValue, 20));
+            } else {
+                Color glowColor;
+                switch (enchantCount) {
+                    case 1:
+                        glowColor = new Color(0, 255, 0); // Green
+                        break;
+                    case 2:
+                        glowColor = new Color(0, 200, 255); // Blue
+                        break;
+                    case 3:
+                        glowColor = new Color(200, 0, 255); // Purple
+                        break;
+                    case 4:
+                        glowColor = new Color(255, 215, 0); // Gold
+                        break;
+                    default:
+                        glowColor = Color.BLACK;
+                }
+                int glowSize = 3;
+                icon = new JLabel(
+                    ImageBuffer.getOutlinedIconWithGlow(
+                        statValue,
+                        20,
+                        glowColor,
+                        glowSize
+                    )
+                );
+            }
+
+            if (!enchantText.isEmpty()) {
+                itemName += "<br>" + enchantText;
             }
             icon.setToolTipText("<html>" + itemName + "</html>");
             panel.add(icon);
@@ -354,7 +468,11 @@ public class LootGUI extends JPanel {
         return width;
     }
 
-    private static void displayBagIcon(Entity entity, long lootTime, JPanel panel) {
+    private static void displayBagIcon(
+        Entity entity,
+        long lootTime,
+        JPanel panel
+    ) {
         int bag = entity.objectType;
         JLabel icon = new JLabel(ImageBuffer.getOutlinedIcon(bag, 20));
         String name = time();
@@ -395,7 +513,9 @@ public class LootGUI extends JPanel {
             dungeonModifiers = dungeonBuff(map.dungeonModifiers3);
             dungeon = ParseDungeon.getPortalId(dungeonName);
             if (dungeon == -1) {
-                CharacterStatistics cs = CharacterStatistics.statByName(dungeonName);
+                CharacterStatistics cs = CharacterStatistics.statByName(
+                    dungeonName
+                );
                 if (cs != null) {
                     dungeon = cs.getSpriteId();
                 } else {
@@ -431,13 +551,17 @@ public class LootGUI extends JPanel {
     }
 
     public static String timeShort() {
-        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("HH:mm:ss");
+        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern(
+            "HH:mm:ss"
+        );
         LocalDateTime dateTime = LocalDateTime.now();
         return dateTimeFormat.format(dateTime);
     }
 
     public static String time() {
-        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH:mm:ss");
+        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern(
+            "yyyy/MM/dd-HH:mm:ss"
+        );
         LocalDateTime dateTime = LocalDateTime.now();
         return dateTimeFormat.format(dateTime);
     }
@@ -460,7 +584,12 @@ public class LootGUI extends JPanel {
             if (!first) s.append(" * ");
             first = false;
             s.append(IdToAsset.objectName(statValue));
-            if (enchants != null && i < enchants.length && !enchants[i].isEmpty() && !enchants[i].equals("AAIE_f_9__3__f8=")) {
+            if (
+                enchants != null &&
+                i < enchants.length &&
+                !enchants[i].isEmpty() &&
+                !enchants[i].equals("AAIE_f_9__3__f8=")
+            ) {
                 s.append("[E]");
             }
             s.append("[").append(statValue).append("]");

--- a/src/main/java/tomato/gui/stats/LootGUI.java
+++ b/src/main/java/tomato/gui/stats/LootGUI.java
@@ -2,10 +2,6 @@ package tomato.gui.stats;
 
 import assets.IdToAsset;
 import assets.ImageBuffer;
-import java.awt.*;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import javax.swing.*;
 import packets.data.StatData;
 import packets.data.enums.StatType;
 import packets.incoming.MapInfoPacket;
@@ -17,7 +13,13 @@ import tomato.realmshark.*;
 import tomato.realmshark.enums.CharacterStatistics;
 import tomato.realmshark.enums.LootBags;
 
+import javax.swing.*;
+import java.awt.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class LootGUI extends JPanel {
+
 
     private static LootGUI INSTANCE;
 
@@ -40,6 +42,7 @@ public class LootGUI extends JPanel {
     public static boolean filterPinkBag = false;
     public static boolean filterBrownBag = false;
 
+
     public LootGUI(TomatoData data) {
         LootGUI.data = data;
         lootDrops = 0;
@@ -59,13 +62,7 @@ public class LootGUI extends JPanel {
         add(scroll, BorderLayout.CENTER);
     }
 
-    public static void update(
-        MapInfoPacket map,
-        Entity bag,
-        Entity dropper,
-        Entity player,
-        long time
-    ) {
+    public static void update(MapInfoPacket map, Entity bag, Entity dropper, Entity player, long time) {
         INSTANCE.updateGui(map, bag, dropper, player, time);
     }
 
@@ -78,13 +75,7 @@ public class LootGUI extends JPanel {
         }
     }
 
-    private void updateGui(
-        MapInfoPacket map,
-        Entity bag,
-        Entity dropper,
-        Entity player,
-        long time
-    ) {
+    private void updateGui(MapInfoPacket map, Entity bag, Entity dropper, Entity player, long time) {
         if (player == null || !update) return;
 
         JPanel panel = createMainBox(map, bag, dropper, player, time);
@@ -93,9 +84,7 @@ public class LootGUI extends JPanel {
         panel.setVisible(isBagVisible(bag));
 
         if (Sound.playWhiteBagSound && isWhiteBag(bag)) Sound.whitebag.play();
-        if (
-            Sound.playOrangeBagSound && isOrangeBag(bag)
-        ) Sound.orangebag.play();
+        if (Sound.playOrangeBagSound && isOrangeBag(bag)) Sound.orangebag.play();
         if (Sound.playRedBagSound && isRedBag(bag)) Sound.redbag.play();
         if (Sound.playGoldBagSound && isGoldBag(bag)) Sound.goldbag.play();
         if (Sound.playRedBagSound && isEggBag(bag)) Sound.redbag.play();
@@ -139,53 +128,37 @@ public class LootGUI extends JPanel {
 
     private boolean isBrownBag(Entity bag) {
         int id = bag.objectType;
-        return (
-            id == LootBags.BROWN.getId() || id == LootBags.BOOSTED_BROWN.getId()
-        );
+        return id == LootBags.BROWN.getId() || id == LootBags.BOOSTED_BROWN.getId();
     }
 
     private boolean isPinkBag(Entity bag) {
         int id = bag.objectType;
-        return (
-            id == LootBags.PINK.getId() || id == LootBags.BOOSTED_PINK.getId()
-        );
+        return id == LootBags.PINK.getId() || id == LootBags.BOOSTED_PINK.getId();
     }
 
     private boolean isPurpleBag(Entity bag) {
         int id = bag.objectType;
-        return (
-            id == LootBags.PURPLE.getId() ||
-            id == LootBags.BOOSTED_PURPLE.getId()
-        );
+        return id == LootBags.PURPLE.getId() || id == LootBags.BOOSTED_PURPLE.getId();
     }
 
     private boolean isTealBag(Entity bag) {
         int id = bag.objectType;
-        return (
-            id == LootBags.TEAL.getId() || id == LootBags.BOOSTED_TEAL.getId()
-        );
+        return id == LootBags.TEAL.getId() || id == LootBags.BOOSTED_TEAL.getId();
     }
 
     private boolean isBlueBag(Entity bag) {
         int id = bag.objectType;
-        return (
-            id == LootBags.BLUE.getId() || id == LootBags.BOOSTED_BLUE.getId()
-        );
+        return id == LootBags.BLUE.getId() || id == LootBags.BOOSTED_BLUE.getId();
     }
 
     private boolean isWhiteBag(Entity bag) {
         int id = bag.objectType;
-        return (
-            id == LootBags.WHITE.getId() || id == LootBags.BOOSTED_WHITE.getId()
-        );
+        return id == LootBags.WHITE.getId() || id == LootBags.BOOSTED_WHITE.getId();
     }
 
     private boolean isOrangeBag(Entity bag) {
         int id = bag.objectType;
-        return (
-            id == LootBags.ORANGE.getId() ||
-            id == LootBags.BOOSTED_ORANGE.getId()
-        );
+        return id == LootBags.ORANGE.getId() || id == LootBags.BOOSTED_ORANGE.getId();
     }
 
     private boolean isRedBag(Entity bag) {
@@ -195,9 +168,7 @@ public class LootGUI extends JPanel {
 
     private boolean isGoldBag(Entity bag) {
         int id = bag.objectType;
-        return (
-            id == LootBags.GOLD.getId() || id == LootBags.BOOSTED_GOLD.getId()
-        );
+        return id == LootBags.GOLD.getId() || id == LootBags.BOOSTED_GOLD.getId();
     }
 
     private boolean isEggBag(Entity bag) {
@@ -210,20 +181,9 @@ public class LootGUI extends JPanel {
         repaint();
     }
 
-    private static JPanel createMainBox(
-        MapInfoPacket map,
-        Entity bag,
-        Entity dropper,
-        Entity player,
-        long time
-    ) {
+    private static JPanel createMainBox(MapInfoPacket map, Entity bag, Entity dropper, Entity player, long time) {
         JPanel mainPanel = new JPanel();
-        mainPanel.setBorder(
-            BorderFactory.createCompoundBorder(
-                BorderFactory.createMatteBorder(0, 0, 1, 0, Color.gray),
-                BorderFactory.createEmptyBorder(0, 20, 0, 20)
-            )
-        );
+        mainPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, Color.gray), BorderFactory.createEmptyBorder(0, 20, 0, 20)));
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.X_AXIS));
 
         mainPanel.putClientProperty("bagEntity", bag); // Store the bag entity for filtering
@@ -243,16 +203,7 @@ public class LootGUI extends JPanel {
         mainPanel.add(Box.createHorizontalStrut(10));
         width = displayTime(mainPanel, width);
         mainPanel.add(Box.createHorizontalStrut(10));
-        width = displayBagDungMob(
-            map,
-            bag,
-            player,
-            dropper,
-            mainPanel,
-            width,
-            exaltBonus,
-            lootTime
-        );
+        width = displayBagDungMob(map, bag, player, dropper, mainPanel, width, exaltBonus, lootTime);
         mainPanel.add(Box.createHorizontalStrut(30));
         width = displayBagLootIcons(bag, mainPanel, width);
 
@@ -263,16 +214,7 @@ public class LootGUI extends JPanel {
         return mainPanel;
     }
 
-    private static int displayBagDungMob(
-        MapInfoPacket map,
-        Entity entity,
-        Entity player,
-        Entity dropper,
-        JPanel mainPanel,
-        int width,
-        int exaltBonus,
-        long lootTime
-    ) {
+    private static int displayBagDungMob(MapInfoPacket map, Entity entity, Entity player, Entity dropper, JPanel mainPanel, int width, int exaltBonus, long lootTime) {
         JPanel panel = new JPanel();
         width += 100;
 
@@ -342,12 +284,7 @@ public class LootGUI extends JPanel {
         return width;
     }
 
-    private static void displayPlayerIcon(
-        MapInfoPacket map,
-        Entity player,
-        int exaltBonus,
-        JPanel panel
-    ) {
+    private static void displayPlayerIcon(MapInfoPacket map, Entity player, int exaltBonus, JPanel panel) {
         int picon = 100;
         boolean isSeasonal = false;
         String name = "Unknown";
@@ -377,12 +314,9 @@ public class LootGUI extends JPanel {
         panel.add(icon);
     }
 
-    private static int displayBagLootIcons(
-        Entity entity,
-        JPanel mainPanel,
-        int width
-    ) {
+    private static int displayBagLootIcons(Entity entity, JPanel mainPanel, int width) {
         JPanel panel = new JPanel();
+//            panel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
         width += 200;
 
         panel.setPreferredSize(new Dimension(200, 24));
@@ -401,64 +335,16 @@ public class LootGUI extends JPanel {
                 JPanel comp = new JPanel();
                 comp.setMinimumSize(new Dimension(24, 24));
                 panel.add(comp);
-                continue;
             }
+            assert sd != null;
             int statValue = sd.statValue;
+            JLabel icon = new JLabel(ImageBuffer.getOutlinedIcon(statValue, 20));
             String itemName = IdToAsset.objectName(statValue);
-            String enchantText = "";
-            int enchantCount = 0;
-
-            if (
-                enchants != null &&
-                i < enchants.length &&
-                !enchants[i].isEmpty() &&
-                !enchants[i].equals("AAIE_f_9__3__f8=")
-            ) {
-                enchantText = ParseEnchants.parse(enchants[i]);
-                if (!enchantText.isEmpty()) {
-                    enchantCount = enchantText.split("\n").length;
+            if (enchants != null && i < enchants.length && !enchants[i].isEmpty() && !enchants[i].equals("AAIE_f_9__3__f8=")) {
+                String e = ParseEnchants.parse(enchants[i]);
+                if (!e.isEmpty()) {
+                    itemName += "<br>" + e;
                 }
-            }
-
-            /* enchantCount Debug: Print enchantCount and itemName
-            System.out.println(
-                "Item: " + itemName + " | EnchantCount: " + enchantCount
-            );*/
-
-            JLabel icon;
-            if (enchantCount == 0) {
-                icon = new JLabel(ImageBuffer.getOutlinedIcon(statValue, 20));
-            } else {
-                Color glowColor;
-                switch (enchantCount) {
-                    case 1:
-                        glowColor = new Color(0, 255, 0); // Green
-                        break;
-                    case 2:
-                        glowColor = new Color(0, 200, 255); // Blue
-                        break;
-                    case 3:
-                        glowColor = new Color(200, 0, 255); // Purple
-                        break;
-                    case 4:
-                        glowColor = new Color(255, 215, 0); // Gold
-                        break;
-                    default:
-                        glowColor = Color.BLACK;
-                }
-                int glowSize = 3;
-                icon = new JLabel(
-                    ImageBuffer.getOutlinedIconWithGlow(
-                        statValue,
-                        20,
-                        glowColor,
-                        glowSize
-                    )
-                );
-            }
-
-            if (!enchantText.isEmpty()) {
-                itemName += "<br>" + enchantText;
             }
             icon.setToolTipText("<html>" + itemName + "</html>");
             panel.add(icon);
@@ -468,11 +354,7 @@ public class LootGUI extends JPanel {
         return width;
     }
 
-    private static void displayBagIcon(
-        Entity entity,
-        long lootTime,
-        JPanel panel
-    ) {
+    private static void displayBagIcon(Entity entity, long lootTime, JPanel panel) {
         int bag = entity.objectType;
         JLabel icon = new JLabel(ImageBuffer.getOutlinedIcon(bag, 20));
         String name = time();
@@ -513,9 +395,7 @@ public class LootGUI extends JPanel {
             dungeonModifiers = dungeonBuff(map.dungeonModifiers3);
             dungeon = ParseDungeon.getPortalId(dungeonName);
             if (dungeon == -1) {
-                CharacterStatistics cs = CharacterStatistics.statByName(
-                    dungeonName
-                );
+                CharacterStatistics cs = CharacterStatistics.statByName(dungeonName);
                 if (cs != null) {
                     dungeon = cs.getSpriteId();
                 } else {
@@ -551,17 +431,13 @@ public class LootGUI extends JPanel {
     }
 
     public static String timeShort() {
-        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern(
-            "HH:mm:ss"
-        );
+        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("HH:mm:ss");
         LocalDateTime dateTime = LocalDateTime.now();
         return dateTimeFormat.format(dateTime);
     }
 
     public static String time() {
-        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern(
-            "yyyy/MM/dd-HH:mm:ss"
-        );
+        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH:mm:ss");
         LocalDateTime dateTime = LocalDateTime.now();
         return dateTimeFormat.format(dateTime);
     }
@@ -584,12 +460,7 @@ public class LootGUI extends JPanel {
             if (!first) s.append(" * ");
             first = false;
             s.append(IdToAsset.objectName(statValue));
-            if (
-                enchants != null &&
-                i < enchants.length &&
-                !enchants[i].isEmpty() &&
-                !enchants[i].equals("AAIE_f_9__3__f8=")
-            ) {
+            if (enchants != null && i < enchants.length && !enchants[i].isEmpty() && !enchants[i].equals("AAIE_f_9__3__f8=")) {
                 s.append("[E]");
             }
             s.append("[").append(statValue).append("]");

--- a/src/main/java/tomato/realmshark/ParseEnchants.java
+++ b/src/main/java/tomato/realmshark/ParseEnchants.java
@@ -3,6 +3,7 @@ package tomato.realmshark;
 import org.xml.sax.SAXException;
 import packets.data.StatData;
 import packets.data.enums.StatType;
+import packets.reader.BufferReader;
 import tomato.backend.data.Entity;
 import util.StringXML;
 
@@ -156,17 +157,21 @@ public class ParseEnchants {
      * @return Decoded enchantment string.
      */
     public static String parse(String code) {
-        if (code.length() == 0) return "";
-        byte[] bytes = PcStatsDecoder.sixBitStringToBytes(code);
+        if (code.isEmpty()) return "";
 
-        ByteBuffer buff = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
-        buff.get();
-        short type = buff.getShort();
-
-        if (type == 1026) {
-            return getEnchantingString(buff, code);
+        BufferReader byteBuffer = new BufferReader(ByteBuffer.wrap(PcStatsDecoder.sixBitStringToBytes(code)).order(ByteOrder.LITTLE_ENDIAN));
+        byteBuffer.readByte();
+        StringBuilder res = new StringBuilder();
+        if (byteBuffer.readShort() != 1026) return res.toString();
+        while (!byteBuffer.isBufferFullyParsed()) {
+            short enchantId = byteBuffer.readShort();
+            if (enchantId == -3) return res.toString();
+            else if (enchantId == -2) return res + "[locked]";
+            else if (enchantId == -1) return res + "empty";
+            res.append(getEnchantmentString(enchantId));
+            res.append("\n");
         }
-        return "";
+        return res.toString();
     }
 
     /**

--- a/src/main/java/tomato/realmshark/ParseEnchants.java
+++ b/src/main/java/tomato/realmshark/ParseEnchants.java
@@ -157,18 +157,34 @@ public class ParseEnchants {
      * @return Decoded enchantment string.
      */
     public static String parse(String code) {
+        //System.out.println("Parsing enchantment code: " + code);
         if (code.isEmpty()) return "";
 
-        BufferReader byteBuffer = new BufferReader(ByteBuffer.wrap(PcStatsDecoder.sixBitStringToBytes(code)).order(ByteOrder.LITTLE_ENDIAN));
+        byte[] rawBytes = PcStatsDecoder.sixBitStringToBytes(code);
+        // Expected buffer size: 1 byte header + 2 bytes type + 4 enchantments (8 bytes)
+        int expectedSize = 1 + 2 + 8;
+        if (rawBytes.length > expectedSize) {
+            rawBytes = Arrays.copyOfRange(rawBytes, 0, expectedSize);
+        }
+
+        BufferReader byteBuffer = new BufferReader(
+                ByteBuffer.wrap(rawBytes).order(ByteOrder.LITTLE_ENDIAN)
+        );
         byteBuffer.readByte();
         StringBuilder res = new StringBuilder();
-        if (byteBuffer.readShort() != 1026) return res.toString();
+        if (byteBuffer.readShort() != 1026) {
+            //System.out.println("Invalid enchantment header, skipping.");
+            return res.toString();
+        }
         while (!byteBuffer.isBufferFullyParsed()) {
             short enchantId = byteBuffer.readShort();
+            //System.out.println("Found enchantment ID: " + enchantId);
             if (enchantId == -3) return res.toString();
             else if (enchantId == -2) return res + "[locked]";
             else if (enchantId == -1) return res + "empty";
-            res.append(getEnchantmentString(enchantId));
+            String enchantName = getEnchantmentString(enchantId);
+            //System.out.println("Enchantment: " + enchantName);
+            res.append(enchantName);
             res.append("\n");
         }
         return res.toString();

--- a/src/main/java/tomato/realmshark/Sound.java
+++ b/src/main/java/tomato/realmshark/Sound.java
@@ -22,6 +22,7 @@ public class Sound {
     public static Sound redbag;
     public static Sound goldbag;
     public static Sound eggbag;
+    public static Sound bluebag;
     public static Sound custom;
     public static Sound trade;
 
@@ -33,6 +34,7 @@ public class Sound {
     public static boolean playRedBagSound = false;
     public static boolean playGoldBagSound = false;
     public static boolean playEggBagSound = false;
+    public static boolean playBlueBagSound = false;
     public static boolean playTradeSound = false;
 
     public Sound(String file) {


### PR DESCRIPTION
DpsToString.java
Add batch processing and throttling to DPS display
Introduce a queue-based system with sampling and throttling to:
- Process DPS data in batches
- Limit updates to 100ms intervals
- Sample input data every 50ms
- Merge consecutive samples
- Maintain last display state for polling

KeypopGUI.java
- Add checkbox to toggle logging to file
- Implement file logging with timestamps
- Persist logging preference in properties
- Remove outdated comment block

TomatoMenuBar.java
Sound.java
LootGUI.java
- additions for blue loot bags to be logged and notified
- persists across loads using properties file
- possibly fixed an issue with egg bags being notified even if disabled
- added rarity glow to Loot tables

ParseEnchants.java
- Fixed decoding new enchantments added to the game

ParsePanelGUI.java
- Add Shift+Click handlers to export names as text
- Add Shift+Click handlers to export all as json
- Implement file saving with timestamped filenames
- Copies exported file object to clipboard
- Show success/error dialogs
- Refactor player filtering logic into separate method

ParsePanelGUI.java & IconDpsGUI.java
Added Glow outlines to items to display number of enchants
- The glow color now vary based on the number of enchants:
- Bright green for 1 enchant
- Cyan blue for 2 enchants
- Vibrant purple for 3 enchants
- Gold for 4 enchants
Non-enchanted items retain their original outline style. (no glow)