### PR TITLE
Hotfix for rotmg 6.2.0.0.0

### DIFF
--- a/src/main/java/packets/data/StatData.java
+++ b/src/main/java/packets/data/StatData.java
@@ -62,6 +62,7 @@ public class StatData implements Serializable {
                 || StatType.CRUCIBLE_STAT.get() == statTypeNum
                 || StatType.DUST_AMOUNT_STAT.get() == statTypeNum
                 || StatType.PET_NAME_STAT.get() == statTypeNum
+                || StatType.UNKNOWN_STRING_155_STAT.get() == statTypeNum
         ) {
             return true;
         }

--- a/src/main/java/packets/data/enums/StatType.java
+++ b/src/main/java/packets/data/enums/StatType.java
@@ -144,6 +144,7 @@ public enum StatType implements Serializable {
     BACKPACK_14_STAT(145),
     BACKPACK_15_STAT(146),
     DUST_AMOUNT_STAT(147),
+    UNKNOWN_STRING_155_STAT(155),
     ;
 
     private final int index;


### PR DESCRIPTION
New StatType 155 was added, which is a String.
This PR fixes the problems caused after the update to version 6.2.0.0.0 where the StatData was being incorrectly deserialized due to the introduction of this new String StatType 155.