### PR TITLE
Asset Path Hotfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-project.version = 'v1.2'
+project.version = 'v1.2.1'
 applicationName = 'RealmShark'
 
 project.ext.lwjglVersion = "3.3.1"

--- a/src/main/java/assets/AssetExtractor.java
+++ b/src/main/java/assets/AssetExtractor.java
@@ -57,7 +57,7 @@ public class AssetExtractor {
                 "RealmOfTheMadGod/Production/RotMGExalt.app/Contents/Resources/Data/resources.assets";
         } else {
             REALM_RES_PATH =
-                "Documents/RealmOfTheMadGod/Production/RotMG Exalt_Data/resources.assets";
+                "RealmOfTheMadGod/Production/RotMG Exalt_Data/resources.assets";
         }
     }
 
@@ -283,7 +283,8 @@ public class AssetExtractor {
             if (Paths.get(REALM_RES_PATH).isAbsolute()) {
                 defaultFile = new File(REALM_RES_PATH);
             } else {
-                String homeDir = System.getProperty("user.home");
+//                String homeDir = System.getProperty("user.home");
+                String homeDir = FileSystemView.getFileSystemView().getDefaultDirectory().getAbsolutePath();
                 Path defaultPath = Paths.get(homeDir, REALM_RES_PATH);
                 defaultFile = defaultPath.toFile();
             }

--- a/src/main/java/realmshark/version/Version.java
+++ b/src/main/java/realmshark/version/Version.java
@@ -3,6 +3,6 @@ package realmshark.version;
  * Don't edit this class. It's a gradle class to grab version from the build.gradle
  */
 public class Version {
-    public static final String VERSION = "v1.2";
+    public static final String VERSION = "v1.2.1";
 }
 


### PR DESCRIPTION
Fixes the Asset Extractor to correctly use the system default directory rather than the home directory, as this appears to be the same logic used by the RotMG Installer to determine the asset folder. This fixes asset extraction for a majority of users

**A corresponding Tomato PR will also be submitted to increment the required version of RealmShark** -> #61 