### PR TITLE
Fix for Necro Summons/Character Tab Disable/Misc

### DIFF
--- a/src/main/java/tomato/backend/TomatoPacketCapture.java
+++ b/src/main/java/tomato/backend/TomatoPacketCapture.java
@@ -72,7 +72,6 @@ public class TomatoPacketCapture implements Controller {
             DamagePacket p = (DamagePacket) packet;
             data.damage(p);
             data.logPacket(packet);
-            //System.out.println(packet);
         } else if (packet instanceof PlayerHitPacket) {
             PlayerHitPacket p = (PlayerHitPacket) packet;
             data.userDamage(p);

--- a/src/main/java/tomato/backend/data/AbilityScalingManager.java
+++ b/src/main/java/tomato/backend/data/AbilityScalingManager.java
@@ -37,9 +37,6 @@ public class AbilityScalingManager {
         public final int scalingMin;
         public final float damagePerStat;
         public final int numShots;
-        public final float ignoreFlat;
-        public final float ignorePerc;
-        public final float statModPerc;
 
         public AbilityScalingData(
             int weaponId,
@@ -48,44 +45,15 @@ public class AbilityScalingManager {
             float damagePerStat,
             int numShots
         ) {
-            this(
-                weaponId,
-                scalingStat,
-                scalingMin,
-                damagePerStat,
-                numShots,
-                0,
-                0,
-                0
-            );
-        }
-
-        public AbilityScalingData(
-            int weaponId,
-            StatType scalingStat,
-            int scalingMin,
-            float damagePerStat,
-            int numShots,
-            float ignoreFlat,
-            float ignorePerc,
-            float statModPerc
-        ) {
             this.weaponId = weaponId;
             this.scalingStat = scalingStat;
             this.scalingMin = scalingMin;
             this.damagePerStat = damagePerStat;
             this.numShots = numShots;
-            this.ignoreFlat = ignoreFlat;
-            this.ignorePerc = ignorePerc;
-            this.statModPerc = statModPerc;
         }
 
         public boolean hasScaling() {
             return scalingStat != null && damagePerStat > 0;
-        }
-
-        public boolean hasDefenseIgnore() {
-            return ignoreFlat > 0 || ignorePerc > 0;
         }
     }
 
@@ -116,7 +84,6 @@ public class AbilityScalingManager {
             document.getDocumentElement().normalize();
 
             parseEquipXml(document);
-            addLethalStrikeProjectileScaling(document);
 
             System.out.println(
                 "AbilityScalingManager initialized with " +
@@ -390,214 +357,6 @@ public class AbilityScalingManager {
         return (end > idx + 2) ? candidate.substring(idx, end) : null;
     }
 
-    private void addLethalStrikeProjectileScaling(Document document) {
-        NodeList objectNodes = document.getElementsByTagName("Object");
-
-        for (int i = 0; i < objectNodes.getLength(); i++) {
-            Node objectNode = objectNodes.item(i);
-            if (objectNode.getNodeType() != Node.ELEMENT_NODE) continue;
-
-            Element objectElement = (Element) objectNode;
-            NodeList lethalStrikeNodes = objectElement.getElementsByTagName(
-                "OnConditionEndActivate"
-            );
-
-            for (int j = 0; j < lethalStrikeNodes.getLength(); j++) {
-                Element lethalStrikeElement = (Element) lethalStrikeNodes.item(
-                    j
-                );
-                if (isLethalStrikeElement(lethalStrikeElement)) {
-                    processLethalStrikeElement(
-                        objectElement,
-                        lethalStrikeElement
-                    );
-                }
-            }
-        }
-    }
-
-    private boolean isLethalStrikeElement(Element element) {
-        if (element == null) return false;
-
-        String text = getElementText(element);
-        String attr = element.getAttribute("type");
-        String combined =
-            (text != null ? text : "") + " " + (attr != null ? attr : "");
-        return combined.toLowerCase().contains("lethalstrike");
-    }
-
-    private String getElementText(Element element) {
-        try {
-            return element.getTextContent() != null
-                ? element.getTextContent()
-                : "";
-        } catch (Exception e) {
-            return "";
-        }
-    }
-
-    private void processLethalStrikeElement(
-        Element objectElement,
-        Element lethalStrikeElement
-    ) {
-        String scalingStatAttr = lethalStrikeElement.getAttribute(
-            "scalingStat"
-        );
-        String statModFlatAttr = lethalStrikeElement.getAttribute(
-            "statModFlat"
-        );
-
-        if (scalingStatAttr.isEmpty() || statModFlatAttr.isEmpty()) return;
-
-        StatType scalingStat = parseStatType(scalingStatAttr);
-        if (scalingStat == null) return;
-
-        int scalingMin = parseScalingMin(lethalStrikeElement);
-        float flatBonus = Float.parseFloat(statModFlatAttr);
-        float percBonus = parseFloatAttr(lethalStrikeElement, "statModPerc");
-        float ignoreFlat = parseFloatAttr(lethalStrikeElement, "ignoreFlat");
-        float ignorePerc = parseFloatAttr(lethalStrikeElement, "ignorePerc");
-        float damagePerStat = flatBonus + (percBonus * 50);
-
-        findAndAddLethalStrikeProjectiles(
-            objectElement,
-            scalingStat,
-            scalingMin,
-            damagePerStat,
-            ignoreFlat,
-            ignorePerc,
-            percBonus
-        );
-    }
-
-    private float parseFloatAttr(Element element, String attrName) {
-        String attr = element.getAttribute(attrName);
-        return !attr.isEmpty() ? Float.parseFloat(attr) : 0;
-    }
-
-    private void findAndAddLethalStrikeProjectiles(
-        Element weaponElement,
-        StatType scalingStat,
-        int scalingMin,
-        float damagePerStat,
-        float ignoreFlat,
-        float ignorePerc,
-        float statModPerc
-    ) {
-        String weaponId = weaponElement.getAttribute("type");
-        if (weaponId.isEmpty()) return;
-
-        Set<Integer> added = new HashSet<>();
-        String[] tagNames = { "OnPlayerShootActivate", "Activate" };
-
-        for (String tagName : tagNames) {
-            NodeList nodes = weaponElement.getElementsByTagName(tagName);
-            for (int i = 0; i < nodes.getLength(); i++) {
-                Element el = (Element) nodes.item(i);
-                extractAndAddProjectiles(
-                    el,
-                    added,
-                    scalingStat,
-                    scalingMin,
-                    damagePerStat,
-                    ignoreFlat,
-                    ignorePerc,
-                    statModPerc
-                );
-            }
-        }
-
-        // Also check Projectile elements
-        NodeList projNodes = weaponElement.getElementsByTagName("Projectile");
-        for (int i = 0; i < projNodes.getLength(); i++) {
-            Element pEl = (Element) projNodes.item(i);
-            extractAndAddProjectiles(
-                pEl,
-                added,
-                scalingStat,
-                scalingMin,
-                damagePerStat,
-                ignoreFlat,
-                ignorePerc,
-                statModPerc
-            );
-        }
-    }
-
-    private void extractAndAddProjectiles(
-        Element element,
-        Set<Integer> added,
-        StatType scalingStat,
-        int scalingMin,
-        float damagePerStat,
-        float ignoreFlat,
-        float ignorePerc,
-        float statModPerc
-    ) {
-        if (element == null || added == null) return;
-
-        String candidate = getCandidate(element);
-        if (candidate == null || candidate.isEmpty()) return;
-
-        candidate = candidate.replaceAll("[^0-9A-Fa-fxX]", "");
-        int idx = candidate.indexOf("0x");
-
-        while (idx != -1 && idx < candidate.length()) {
-            int end = idx + 2;
-            while (
-                end < candidate.length() &&
-                Character.digit(candidate.charAt(end), 16) != -1
-            ) {
-                end++;
-            }
-
-            if (end > idx + 2) {
-                try {
-                    int projectileId = Integer.parseInt(
-                        candidate.substring(idx + 2, end),
-                        16
-                    );
-                    if (!added.contains(projectileId)) {
-                        AbilityScalingData projectileScaling =
-                            new AbilityScalingData(
-                                projectileId,
-                                scalingStat,
-                                scalingMin,
-                                damagePerStat,
-                                1,
-                                ignoreFlat,
-                                ignorePerc,
-                                statModPerc
-                            );
-                        projectileScalingData.put(
-                            projectileId,
-                            projectileScaling
-                        );
-                        added.add(projectileId);
-                    }
-                } catch (NumberFormatException e) {
-                    // Skip invalid hex
-                }
-            }
-            idx = candidate.indexOf("0x", idx + 1);
-        }
-    }
-
-    private String getCandidate(Element element) {
-        if (element == null) return "";
-
-        String typeAttr = element.getAttribute("type");
-        if (typeAttr != null && !typeAttr.isEmpty()) {
-            return typeAttr.trim();
-        }
-        String idAttr = element.getAttribute("id");
-        if (idAttr != null && !idAttr.isEmpty()) {
-            return idAttr.trim();
-        }
-        String text = element.getTextContent();
-        return text != null ? text.trim() : "";
-    }
-
     /**
      * Gets scaling data for a specific weapon ID.
      */
@@ -683,61 +442,6 @@ public class AbilityScalingManager {
             }
         }
         return 1.0f;
-    }
-
-    /**
-     * Calculates the defense ignore bonus for Lethal Strike.
-     */
-    public int calculateDefenseIgnoreBonus(
-        int weaponId,
-        int targetDefense,
-        Entity player
-    ) {
-        return calculateDefenseIgnoreBonus(
-            weaponId,
-            targetDefense,
-            null,
-            player
-        );
-    }
-
-    /**
-     * Calculates the defense ignore bonus for Lethal Strike.
-     * If statSnapshot is non-null, that value will be used for percentage scaling.
-     */
-    public int calculateDefenseIgnoreBonus(
-        int weaponId,
-        int targetDefense,
-        Integer statSnapshot,
-        Entity player
-    ) {
-        AbilityScalingData data = getScalingData(weaponId);
-        if (
-            data == null ||
-            !data.hasDefenseIgnore() ||
-            targetDefense <= 0 ||
-            player == null
-        ) {
-            return 0;
-        }
-
-        Integer statValue = (statSnapshot != null)
-            ? statSnapshot
-            : getPlayerStatValue(player, data.scalingStat);
-
-        if (statValue == null || statValue <= data.scalingMin) {
-            int defenseIgnore = (int) (data.ignoreFlat +
-                (targetDefense * data.ignorePerc));
-            return Math.max(0, defenseIgnore);
-        }
-
-        int statBonus = statValue - data.scalingMin;
-        float scaledIgnorePerc =
-            data.ignorePerc + (statBonus * data.statModPerc);
-        int defenseIgnore = (int) (data.ignoreFlat +
-            (targetDefense * scaledIgnorePerc));
-
-        return Math.max(0, defenseIgnore);
     }
 
     private Integer getPlayerStatValue(Entity player, StatType statType) {

--- a/src/main/java/tomato/backend/data/Damage.java
+++ b/src/main/java/tomato/backend/data/Damage.java
@@ -1,6 +1,7 @@
 package tomato.backend.data;
 
 import java.io.Serializable;
+import packets.data.StatData;
 import packets.data.enums.StatType;
 import tomato.realmshark.ParseEnchants;
 
@@ -10,10 +11,10 @@ import tomato.realmshark.ParseEnchants;
 public class Damage implements Serializable {
 
     public Entity owner;
+    public int ownerObjectType;
+    public String ownerObjectName;
     public int[] ownerInvntory;
     public String[] ownerEnchants;
-    // Inventory slot 1 is the ability/item slot for Lethal Strike procs.
-    public int ownerAbilityItem;
     // Generic snapshot of the relevant scaling stat captured at damage-creation time.
     // If ownerScalingStatType == null, no snapshot was captured. ownerScalingStatValue may be null
     // when the stat type is known but the specific stat value wasn't available.
@@ -40,8 +41,6 @@ public class Damage implements Serializable {
         //             (ownerInvntory != null
         //                 ? java.util.Arrays.toString(ownerInvntory)
         //                 : "null") +
-        //             " abilityItem=" +
-        //             ownerAbilityItem +
         //             " enchants=" +
         //             (ownerEnchants != null
         //                 ? java.util.Arrays.toString(ownerEnchants)
@@ -97,8 +96,6 @@ public class Damage implements Serializable {
         //             (ownerInvntory != null
         //                 ? java.util.Arrays.toString(ownerInvntory)
         //                 : "null") +
-        //             " abilityItem=" +
-        //             ownerAbilityItem +
         //             " enchants=" +
         //             (ownerEnchants != null
         //                 ? java.util.Arrays.toString(ownerEnchants)
@@ -160,8 +157,6 @@ public class Damage implements Serializable {
         //             (ownerInvntory != null
         //                 ? java.util.Arrays.toString(ownerInvntory)
         //                 : "null") +
-        //             " abilityItem=" +
-        //             ownerAbilityItem +
         //             " enchants=" +
         //             (ownerEnchants != null
         //                 ? java.util.Arrays.toString(ownerEnchants)
@@ -207,29 +202,36 @@ public class Damage implements Serializable {
 
     private void setInv(Entity o) {
         if (o != null && o.stat != null) {
-            ownerInvntory = new int[] {
-                o.stat.get(StatType.INVENTORY_0_STAT).statValue,
-                o.stat.get(StatType.INVENTORY_1_STAT).statValue,
-                o.stat.get(StatType.INVENTORY_2_STAT).statValue,
-                o.stat.get(StatType.INVENTORY_3_STAT).statValue,
-            };
-            ownerEnchants = ParseEnchants.getEnchantStrings(o);
-            // Record the ability slot (inventory index 1) used for Lethal Strike attribution.
-            try {
-                ownerAbilityItem = ownerInvntory.length > 1
-                    ? ownerInvntory[1]
-                    : -1;
-            } catch (Exception e) {
-                ownerAbilityItem = -1;
+            ownerObjectType = o.objectType;
+            ownerObjectName = o.name();
+
+            // Check if entity has inventory stats (players have them, pets/minions don't)
+            StatData inv0 = o.stat.get(StatType.INVENTORY_0_STAT);
+            StatData inv1 = o.stat.get(StatType.INVENTORY_1_STAT);
+            StatData inv2 = o.stat.get(StatType.INVENTORY_2_STAT);
+            StatData inv3 = o.stat.get(StatType.INVENTORY_3_STAT);
+
+            if (inv0 != null && inv1 != null && inv2 != null && inv3 != null) {
+                ownerInvntory = new int[] {
+                    inv0.statValue,
+                    inv1.statValue,
+                    inv2.statValue,
+                    inv3.statValue,
+                };
+            } else {
+                // Entity doesn't have inventory (pet, minion, etc.)
+                ownerInvntory = new int[] { -1, -1, -1, -1 };
             }
+            ownerEnchants = ParseEnchants.getEnchantStrings(o);
 
             // Generic: clear any scaling stat snapshot here. Specific constructors that know the projectile
             // will populate ownerScalingStatType and ownerScalingStatValue after this call.
             ownerScalingStatType = null;
             ownerScalingStatValue = null;
         } else {
+            ownerObjectType = -1;
+            ownerObjectName = null;
             ownerInvntory = null;
-            ownerAbilityItem = -1;
             ownerScalingStatType = null;
             ownerScalingStatValue = null;
         }

--- a/src/main/java/tomato/backend/data/Entity.java
+++ b/src/main/java/tomato/backend/data/Entity.java
@@ -254,15 +254,18 @@ public class Entity implements Serializable {
             } else {
                 // Non-armor piercing abilities should consider target defense
                 int[] conditions = new int[2];
-                conditions[0] = stat.get(StatType.CONDITION_STAT) == null
-                    ? 0
-                    : stat.get(StatType.CONDITION_STAT).statValue;
-                conditions[1] = stat.get(StatType.NEW_CON_STAT) == null
-                    ? 0
-                    : stat.get(StatType.NEW_CON_STAT).statValue;
-                int defence = stat.get(StatType.DEFENSE_STAT) == null
-                    ? 0
-                    : stat.get(StatType.DEFENSE_STAT).statValue;
+                conditions[0] =
+                    stat.get(StatType.CONDITION_STAT) == null
+                        ? 0
+                        : stat.get(StatType.CONDITION_STAT).statValue;
+                conditions[1] =
+                    stat.get(StatType.NEW_CON_STAT) == null
+                        ? 0
+                        : stat.get(StatType.NEW_CON_STAT).statValue;
+                int defence =
+                    stat.get(StatType.DEFENSE_STAT) == null
+                        ? 0
+                        : stat.get(StatType.DEFENSE_STAT).statValue;
 
                 dmg = Projectile.damageWithDefense(
                     baseDamage,
@@ -351,129 +354,36 @@ public class Entity implements Serializable {
             }
 
             // Apply defense calculations to all projectiles with containerType
-            // This ensures Lethal Strike defense ignore and proper scaling are applied
+            // This ensures proper scaling is applied
             if (containerType != -1 || !isProcProjectile) {
                 // Calculate damage client-side with defense for all projectiles with containerType
                 int[] conditions = new int[2];
 
-                conditions[0] = stat.get(StatType.CONDITION_STAT) == null
-                    ? 0
-                    : stat.get(StatType.CONDITION_STAT).statValue;
-                conditions[1] = stat.get(StatType.NEW_CON_STAT) == null
-                    ? 0
-                    : stat.get(StatType.NEW_CON_STAT).statValue;
-                int defence = stat.get(StatType.DEFENSE_STAT) == null
-                    ? 0
-                    : stat.get(StatType.DEFENSE_STAT).statValue;
+                conditions[0] =
+                    stat.get(StatType.CONDITION_STAT) == null
+                        ? 0
+                        : stat.get(StatType.CONDITION_STAT).statValue;
+                conditions[1] =
+                    stat.get(StatType.NEW_CON_STAT) == null
+                        ? 0
+                        : stat.get(StatType.NEW_CON_STAT).statValue;
+                int defence =
+                    stat.get(StatType.DEFENSE_STAT) == null
+                        ? 0
+                        : stat.get(StatType.DEFENSE_STAT).statValue;
 
                 // For proc projectiles with scaling, use the stat-scaled damage as base
                 int baseDamage = isProcProjectile
                     ? dmg
                     : projectile.getDamage();
 
-                // Only log defense-application details for local-user projectiles (we don't need to debug other players' client-side defense calc)
-                if (attacker != null && attacker.isUser()) {
-                    // Only log defense-application details for lethal-strike/scaling projectiles that originate from the local user.
-                    // We don't need client-side defense debug info for other players' shots.
-                    if (
-                        attacker != null &&
-                        attacker.isUser() &&
-                        AbilityScalingManager.getInstance().hasScaling(
-                            containerType
-                        )
-                    ) {
-                        System.out.println(
-                            "[Entity] userProjectileHit: applying defense. baseDamage=" +
-                                baseDamage +
-                                " ap=" +
-                                projectile.isArmorPiercing() +
-                                " defence=" +
-                                defence +
-                                " conditions=[" +
-                                conditions[0] +
-                                "," +
-                                conditions[1] +
-                                "] containerType=" +
-                                projectile.getContainerType()
-                        );
-                    }
-                }
-
-                // If we have a containerType (ability projectile), compute defense-ignore using a stat snapshot if available.
-                if (projectile != null && projectile.getContainerType() != -1) {
-                    Integer statSnapshot = null;
-                    try {
-                        // Prefer damage-time / current attacker stat for defense-ignore calculation.
-                        AbilityScalingManager.AbilityScalingData sd =
-                            scalingManager.getScalingData(
-                                projectile.getContainerType()
-                            );
-                        if (
-                            attacker != null &&
-                            sd != null &&
-                            sd.scalingStat != null &&
-                            attacker.stat.get(sd.scalingStat) != null
-                        ) {
-                            statSnapshot = Integer.valueOf(
-                                attacker.stat.get(sd.scalingStat).statValue
-                            );
-                        } else if (projectile != null) {
-                            int s = projectile.getOriginScalingStat();
-                            if (s != Integer.MIN_VALUE) {
-                                statSnapshot = Integer.valueOf(s);
-                            }
-                        }
-                    } catch (Exception ignored) {}
-                    int defenseIgnoreBonus =
-                        scalingManager.calculateDefenseIgnoreBonus(
-                            projectile.getContainerType(),
-                            defence,
-                            statSnapshot,
-                            attacker
-                        );
-                    if (defenseIgnoreBonus > 0) {
-                        defence = Math.max(0, defence - defenseIgnoreBonus);
-                        // Only log defense-ignore details when the attacker is the local user AND the ability is a scaling (lethal-strike) ability.
-                        if (
-                            attacker != null &&
-                            attacker.isUser() &&
-                            AbilityScalingManager.getInstance().hasScaling(
-                                projectile.getContainerType()
-                            )
-                        ) {
-                            System.out.println(
-                                "[Entity] userProjectileHit: applied defense ignore=" +
-                                    defenseIgnoreBonus +
-                                    " newDefence=" +
-                                    defence +
-                                    (statSnapshot != null
-                                        ? " (used snapshot)"
-                                        : " (used current)")
-                            );
-                        }
-                    }
-                }
-
-                // Now apply the standard defense calculation with the (possibly adjusted) defence value.
+                // Apply the standard defense calculation
                 dmg = Projectile.damageWithDefense(
                     baseDamage,
                     projectile.isArmorPiercing(),
                     defence,
                     conditions
                 );
-                // Only print final-damage when this was a local-user scaling (lethal-strike) calculation.
-                if (
-                    attacker != null &&
-                    attacker.isUser() &&
-                    AbilityScalingManager.getInstance().hasScaling(
-                        containerType
-                    )
-                ) {
-                    System.out.println(
-                        "[Entity] userProjectileHit: final damage after defense=" +
-                            dmg
-                    );
-                }
             }
         }
 
@@ -557,6 +467,10 @@ public class Entity implements Serializable {
         }
 
         Damage damage = new Damage(attacker, projectile, time, damageAmount);
+
+        // Log damage object creation
+        // Damage object created - attacker info available in Damage.owner field
+
         bossPhaseDamage(damage);
         addPlayerDmg(damage);
         // Commented out noisy diagnostic logs (preserved original lines as comments)
@@ -786,9 +700,8 @@ public class Entity implements Serializable {
             if (r != null) {
                 r.fame = fame;
                 // Pass character class name to fame table
-                String className = r.classString != null
-                    ? r.classString
-                    : "Char " + charId;
+                String className =
+                    r.classString != null ? r.classString : "Char " + charId;
                 FameTableBridge.updateFame(charId, fame, time, className);
             } else {
                 // Try to get class name from ObjectType if character not in charMap

--- a/src/main/java/tomato/backend/data/Projectile.java
+++ b/src/main/java/tomato/backend/data/Projectile.java
@@ -172,13 +172,12 @@ public class Projectile implements Serializable {
 
     /**
      * Used when an entity takes damage taking defence and other effects into account for final damage to entity.
-     * This version includes weaponId for Lethal Strike defense ignore calculations.
      *
      * @param damage        the base damage the bullet can do.
      * @param armorPiercing if the bullet ignores defence.
      * @param defence       defence of the entity being hit.
      * @param conditions    condition effects the entity being shot can have.
-     * @param weaponId      the weapon ID for Lethal Strike defense ignore calculations.
+     * @param weaponId      the weapon ID (kept for compatibility but no longer used for defense calculations).
      * @return final damage applied to the entity.
      */
     public static int damageWithDefense(
@@ -190,20 +189,6 @@ public class Projectile implements Serializable {
         Entity player
     ) {
         if (damage == 0) return 0;
-
-        // Apply Lethal Strike defense ignore if weapon has it
-        if (weaponId != -1 && player != null) {
-            AbilityScalingManager scalingManager =
-                AbilityScalingManager.getInstance();
-            int defenseIgnoreBonus = scalingManager.calculateDefenseIgnoreBonus(
-                weaponId,
-                defence,
-                player
-            );
-            if (defenseIgnoreBonus > 0) {
-                defence = Math.max(0, defence - defenseIgnoreBonus);
-            }
-        }
 
         if (armorPiercing || (conditions[0] & 0x4000000) != 0) {
             defence = 0;

--- a/src/main/java/tomato/backend/data/TomatoData.java
+++ b/src/main/java/tomato/backend/data/TomatoData.java
@@ -83,6 +83,10 @@ public class TomatoData {
     private final HashMap<String, ArrayList<String>> propLists =
         new HashMap<>();
 
+    // Track minion/summon to owner mapping for damage attribution
+    // Key: minion/summon objectId, Value: owner/player objectId
+    private final HashMap<Integer, Integer> minionOwnerMap = new HashMap<>();
+
     /**
      * Sets the current realm.
      *
@@ -199,6 +203,9 @@ public class TomatoData {
             crystalTracker.remove(dropId);
             Entity e = entityList.get(dropId);
             dropList.put(dropId, e);
+
+            // Clean up minion ownership mapping when minion despawns
+            minionOwnerMap.remove(dropId);
             if (e != null) {
                 //                e.entityDropped(timePc);
                 if (isPlayerEntity(e.objectType)) {
@@ -461,7 +468,7 @@ public class TomatoData {
     }
 
     /**
-     * Handles special projectile creations from the outgoing packet.
+     * Projectile info of other players.
      *
      * @param p Projectile info
      */
@@ -470,6 +477,28 @@ public class TomatoData {
         Entity ownerEntity = playerList.get(p.ownerId);
         if (ownerEntity != null) {
             Entity.trackSlotType18AbilityUse(ownerEntity, timePc);
+        }
+
+        /*
+         * MINION/SUMMON DAMAGE ATTRIBUTION:
+         * When pets, minions, traps, or other summons shoot projectiles, the game sends
+         * ServerPlayerShootPacket with:
+         *   - ownerId = the minion/summon entity's objectId (e.g., objectType=5805 for traps)
+         *   - summonerId = the player owner's objectId (e.g., objectType=801 for players)
+         *
+         * We track this relationship in minionOwnerMap so that when DamagePacket arrives
+         * with the minion's objectId as the attacker, we can attribute the damage to the
+         * player owner instead of showing "NO_NAME" in DPS logs.
+         *
+         * Example flow:
+         * 1. ServerPlayerShootPacket: ownerId=218776 (minion), summonerId=202734 (player "BinaryGhost")
+         *    → We store: minionOwnerMap[218776] = 202734
+         * 2. DamagePacket: objectId=218776 (minion did damage)
+         *    → We lookup: minionOwnerMap.get(218776) → 202734
+         *    → Damage attributed to "BinaryGhost" instead of "NO_NAME"
+         */
+        if (p.summonerId != 0 && p.ownerId != 0) {
+            minionOwnerMap.put(p.ownerId, p.summonerId);
         }
 
         if (p.bulletCount > 1) {
@@ -663,7 +692,38 @@ public class TomatoData {
         Entity target = entityList.computeIfAbsent(id, idd ->
             new Entity(this, idd, timePc)
         );
+
+        /*
+         * ATTACKER RESOLUTION & MINION DAMAGE ATTRIBUTION:
+         * DamagePacket.objectId contains the entity ID of whoever/whatever dealt the damage.
+         * This could be:
+         *   1. A player (found in playerList)
+         *   2. A pet/minion/summon/trap (found in entityList, not playerList)
+         *
+         * For minions/summons, we check minionOwnerMap (populated by ServerPlayerShootPacket)
+         * to find the player owner and attribute damage to them instead of showing "NO_NAME".
+         *
+         * This ensures all player-owned entities' damage appears under the player's name in DPS logs.
+         */
         Entity attacker = playerList.get(p.objectId);
+
+        // Fallback to entityList if not found in playerList (handles pets, minions, summons, etc.)
+        if (attacker == null) {
+            attacker = entityList.get(p.objectId);
+
+            if (attacker != null) {
+                // Check if this entity is a minion/summon with a known owner
+                Integer ownerId = minionOwnerMap.get(p.objectId);
+                if (ownerId != null) {
+                    Entity owner = playerList.get(ownerId);
+                    if (owner != null) {
+                        // Replace attacker with the owner for damage attribution
+                        attacker = owner;
+                    }
+                }
+            }
+        }
+
         if (p.damageAmount > 0) {
             Projectile projectile = new Projectile(p.damageAmount);
             target.genericDamageHit(attacker, projectile, timePc);
@@ -674,6 +734,7 @@ public class TomatoData {
                 }
             }
         }
+
         target.updateDamageTaken(timePc);
     }
 
@@ -800,6 +861,8 @@ public class TomatoData {
         lootBags.clear();
 
         enemyProjectiles.clear();
+
+        minionOwnerMap.clear();
 
         deathNotifications = new ArrayList<>();
 

--- a/src/main/java/tomato/gui/TomatoGUI.java
+++ b/src/main/java/tomato/gui/TomatoGUI.java
@@ -67,8 +67,9 @@ public class TomatoGUI {
         securityPanel = new SecurityGUI();
         tabbedPane.addTab("Security", securityPanel);
 
-        characterPanel = new CharacterPanelGUI(data);
-        tabbedPane.addTab("Characters", characterPanel);
+        // Temporarily disabled - non-functional
+        // characterPanel = new CharacterPanelGUI(data);
+        // tabbedPane.addTab("Characters", characterPanel);
 
         statistics = new StatisticsGUI(data);
         tabbedPane.addTab("Statistics", statistics);

--- a/src/main/java/tomato/gui/character/CharacterCollectionGUI.java
+++ b/src/main/java/tomato/gui/character/CharacterCollectionGUI.java
@@ -1,11 +1,6 @@
 package tomato.gui.character;
 
 import assets.ImageBuffer;
-import tomato.backend.data.TomatoData;
-import tomato.realmshark.DungeonCollection;
-import tomato.realmshark.RealmCharacter;
-
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -13,11 +8,16 @@ import java.awt.event.MouseWheelEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import javax.swing.*;
+import tomato.backend.data.TomatoData;
+import tomato.realmshark.DungeonCollection;
+import tomato.realmshark.RealmCharacter;
 
 /**
  * Dungeon completion display GUI class showing all dungeon completions of the users account.
  */
 public class CharacterCollectionGUI extends JPanel {
+
     private static CharacterCollectionGUI INSTANCE;
     private final JPanel left, right;
     private final int collectionCount;
@@ -40,16 +40,26 @@ public class CharacterCollectionGUI extends JPanel {
         JScrollPane spLeft = new JScrollPane(left);
         JScrollPane spRight = new JScrollPane(right);
 
-        spRight.getHorizontalScrollBar().setModel(spTop.getHorizontalScrollBar().getModel());
-        spRight.getVerticalScrollBar().setModel(spLeft.getVerticalScrollBar().getModel());
+        spRight
+            .getHorizontalScrollBar()
+            .setModel(spTop.getHorizontalScrollBar().getModel());
+        spRight
+            .getVerticalScrollBar()
+            .setModel(spLeft.getVerticalScrollBar().getModel());
         spTop.getHorizontalScrollBar().setUnitIncrement(3);
         spRight.getVerticalScrollBar().setUnitIncrement(9);
 
-        spLeft.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        spLeft.setHorizontalScrollBarPolicy(
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+        );
         spLeft.getVerticalScrollBar().setUnitIncrement(9);
 
-        spRight.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        spRight.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
+        spRight.setHorizontalScrollBarPolicy(
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+        );
+        spRight.setVerticalScrollBarPolicy(
+            JScrollPane.VERTICAL_SCROLLBAR_NEVER
+        );
         spTop.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
 
         setLayout(new BorderLayout());
@@ -62,18 +72,20 @@ public class CharacterCollectionGUI extends JPanel {
         topLeft.setPreferredSize(new Dimension(37, 37));
         topLeftLabel = new JLabel(getImageIcon(810), JLabel.CENTER);
         topLeft.add(topLeftLabel);
-        topLeftLabel.addMouseListener(new MouseAdapter() {
-            public void mouseClicked(MouseEvent e) {
-                if (data.chars == null) return;
-                sortOrder = !sortOrder;
-                if (sortOrder) {
-                    data.chars.sort(Comparator.comparingLong(o -> o.fame));
-                } else {
-                    data.chars.sort(Comparator.comparingLong(o -> -o.fame));
+        topLeftLabel.addMouseListener(
+            new MouseAdapter() {
+                public void mouseClicked(MouseEvent e) {
+                    if (data.chars == null) return;
+                    sortOrder = !sortOrder;
+                    if (sortOrder) {
+                        data.chars.sort(Comparator.comparingLong(o -> o.fame));
+                    } else {
+                        data.chars.sort(Comparator.comparingLong(o -> -o.fame));
+                    }
+                    update();
                 }
-                update();
             }
-        });
+        );
 
         leftBar.add(topLeft, BorderLayout.NORTH);
         leftBar.add(spLeft, BorderLayout.CENTER);
@@ -97,28 +109,32 @@ public class CharacterCollectionGUI extends JPanel {
         top.setLayout(new GridLayout(1, collectionCount));
 
         for (int j = 0; j < collectionCount; j++) {
-            JLabel dungeonIcon = new JLabel(DungeonCollection.collectionShort[j]);
+            JLabel dungeonIcon = new JLabel(
+                DungeonCollection.collectionShort[j]
+            );
             String t1 = DungeonCollection.collection[j];
             String t2 = DungeonCollection.collectionBonus[j];
 
             dungeonIcon.setToolTipText("<html>" + t1 + "<br>" + t2 + "</html>");
 
-//            int finalJ = j;
-//            dungeonIcon.addMouseListener(new MouseAdapter() {
-//                public void mouseClicked(MouseEvent e) {
-//                    if (data.chars == null) return;
-//                    sortOrder = !sortOrder;
-//                    if (sortOrder) {
-//                        data.chars.sort(Comparator.comparingLong(o -> -o.charStats.dungeonStats[finalJ]));
-//                    } else {
-//                        data.chars.sort(Comparator.comparingLong(o -> o.charStats.dungeonStats[finalJ]));
-//                    }
-//                    update();
-//                }
-//            });
+            //            int finalJ = j;
+            //            dungeonIcon.addMouseListener(new MouseAdapter() {
+            //                public void mouseClicked(MouseEvent e) {
+            //                    if (data.chars == null) return;
+            //                    sortOrder = !sortOrder;
+            //                    if (sortOrder) {
+            //                        data.chars.sort(Comparator.comparingLong(o -> -o.charStats.dungeonStats[finalJ]));
+            //                    } else {
+            //                        data.chars.sort(Comparator.comparingLong(o -> o.charStats.dungeonStats[finalJ]));
+            //                    }
+            //                    update();
+            //                }
+            //            });
 
             JPanel p = new JPanel();
-            p.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+            p.setBorder(
+                BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+            );
             p.add(dungeonIcon);
             p.setPreferredSize(new Dimension(35, 37));
             top.add(p);
@@ -129,6 +145,7 @@ public class CharacterCollectionGUI extends JPanel {
      * Method for receiving realm character list info.
      */
     public static void updateRealmChars() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.update();
     }
 
@@ -157,7 +174,10 @@ public class CharacterCollectionGUI extends JPanel {
             RealmCharacter c = data.chars.get(i);
 
             for (int j = 0; j < collectionCount; j++) {
-                ArrayList<String> l = DungeonCollection.collection(DungeonCollection.collection[j], c);
+                ArrayList<String> l = DungeonCollection.collection(
+                    DungeonCollection.collection[j],
+                    c
+                );
                 JLabel jLabel = labels[i][j];
                 if (jLabel != null && l != null) {
                     if (l.isEmpty()) {
@@ -165,7 +185,9 @@ public class CharacterCollectionGUI extends JPanel {
                         jLabel.setToolTipText("");
                     } else {
                         jLabel.setText("0");
-                        StringBuilder s = new StringBuilder("<html>Missing:<br>");
+                        StringBuilder s = new StringBuilder(
+                            "<html>Missing:<br>"
+                        );
                         for (String d : l) {
                             s.append(d).append("<br>");
                         }
@@ -188,7 +210,9 @@ public class CharacterCollectionGUI extends JPanel {
             RealmCharacter c = data.chars.get(i);
             JLabel player = playerIcon(c);
             JPanel p = new JPanel(new GridBagLayout());
-            p.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+            p.setBorder(
+                BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+            );
             p.setPreferredSize(new Dimension(150, 27));
             p.add(player);
 
@@ -212,7 +236,9 @@ public class CharacterCollectionGUI extends JPanel {
         for (int i = 0; i < charCount; i++) {
             for (int j = 0; j < collectionCount; j++) {
                 JPanel p2 = new JPanel();
-                p2.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+                p2.setBorder(
+                    BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+                );
                 labels[i][j] = new JLabel();
                 p2.add(labels[i][j]);
                 p2.setPreferredSize(new Dimension(35, 27));
@@ -232,23 +258,29 @@ public class CharacterCollectionGUI extends JPanel {
             int eq = c.skin;
             if (eq == 0) eq = c.classNum;
             ImageIcon icon = getImageIcon(eq);
-            JLabel characterLabel = new JLabel(c.classString + " " + c.fame, icon, JLabel.CENTER);
-            characterLabel.addMouseListener(new MouseAdapter() {
-                public void mouseClicked(MouseEvent e) {
-                    if (data.chars == null) return;
-                    boolean b = data.chars.remove(c);
-                    if (b) {
-                        data.chars.add(0, c);
+            JLabel characterLabel = new JLabel(
+                c.classString + " " + c.fame,
+                icon,
+                JLabel.CENTER
+            );
+            characterLabel.addMouseListener(
+                new MouseAdapter() {
+                    public void mouseClicked(MouseEvent e) {
+                        if (data.chars == null) return;
+                        boolean b = data.chars.remove(c);
+                        if (b) {
+                            data.chars.add(0, c);
+                        }
+                        //                    sortOrder = !sortOrder;
+                        //                    if (sortOrder) {
+                        //                        data.chars.sort(Comparator.comparingLong(o -> -o.fame));
+                        //                    } else {
+                        //                        data.chars.sort(Comparator.comparingLong(o -> o.fame));
+                        //                    }
+                        update();
                     }
-//                    sortOrder = !sortOrder;
-//                    if (sortOrder) {
-//                        data.chars.sort(Comparator.comparingLong(o -> -o.fame));
-//                    } else {
-//                        data.chars.sort(Comparator.comparingLong(o -> o.fame));
-//                    }
-                    update();
                 }
-            });
+            );
             return characterLabel;
         } catch (Exception e) {
             e.printStackTrace();
@@ -270,29 +302,42 @@ public class CharacterCollectionGUI extends JPanel {
      * Horizontal scroll class
      */
     class HorizontalJScrollPane extends JScrollPane {
+
         public HorizontalJScrollPane(Component component) {
             super(component);
             final JScrollBar horizontalScrollBar = getHorizontalScrollBar();
             setWheelScrollingEnabled(false);
-            addMouseWheelListener(new MouseAdapter() {
-                public void mouseWheelMoved(MouseWheelEvent evt) {
-
-                    int iScrollAmount = horizontalScrollBar.getUnitIncrement();
-                    if (evt.getWheelRotation() >= 1)//mouse wheel was rotated down/ towards the user
-                    {
-                        int iNewValue = horizontalScrollBar.getValue() + horizontalScrollBar.getBlockIncrement() * iScrollAmount * Math.abs(evt.getWheelRotation());
-                        if (iNewValue <= horizontalScrollBar.getMaximum()) {
-                            horizontalScrollBar.setValue(iNewValue);
-                        }
-                    } else if (evt.getWheelRotation() <= -1)//mouse wheel was rotated up/away from the user
-                    {
-                        int iNewValue = horizontalScrollBar.getValue() - horizontalScrollBar.getBlockIncrement() * iScrollAmount * Math.abs(evt.getWheelRotation());
-                        if (iNewValue >= 0) {
-                            horizontalScrollBar.setValue(iNewValue);
+            addMouseWheelListener(
+                new MouseAdapter() {
+                    public void mouseWheelMoved(MouseWheelEvent evt) {
+                        int iScrollAmount =
+                            horizontalScrollBar.getUnitIncrement();
+                        if (
+                            evt.getWheelRotation() >= 1 //mouse wheel was rotated down/ towards the user
+                        ) {
+                            int iNewValue =
+                                horizontalScrollBar.getValue() +
+                                horizontalScrollBar.getBlockIncrement() *
+                                iScrollAmount *
+                                Math.abs(evt.getWheelRotation());
+                            if (iNewValue <= horizontalScrollBar.getMaximum()) {
+                                horizontalScrollBar.setValue(iNewValue);
+                            }
+                        } else if (
+                            evt.getWheelRotation() <= -1 //mouse wheel was rotated up/away from the user
+                        ) {
+                            int iNewValue =
+                                horizontalScrollBar.getValue() -
+                                horizontalScrollBar.getBlockIncrement() *
+                                iScrollAmount *
+                                Math.abs(evt.getWheelRotation());
+                            if (iNewValue >= 0) {
+                                horizontalScrollBar.setValue(iNewValue);
+                            }
                         }
                     }
                 }
-            });
+            );
         }
     }
 }

--- a/src/main/java/tomato/gui/character/CharacterExaltGUI.java
+++ b/src/main/java/tomato/gui/character/CharacterExaltGUI.java
@@ -1,17 +1,16 @@
 package tomato.gui.character;
 
 import assets.ImageBuffer;
-import tomato.realmshark.RealmCharacter;
-import tomato.backend.data.TomatoData;
-import tomato.realmshark.enums.CharacterClass;
-
-import javax.swing.*;
 import java.awt.*;
+import javax.swing.*;
+import tomato.backend.data.TomatoData;
+import tomato.realmshark.RealmCharacter;
+import tomato.realmshark.enums.CharacterClass;
 
 public class CharacterExaltGUI extends JPanel {
 
     private static CharacterExaltGUI INSTANCE;
-    private static final int[] exaltOrder = {7, 6, 5, 4, 1, 0, 2, 3};
+    private static final int[] exaltOrder = { 7, 6, 5, 4, 1, 0, 2, 3 };
 
     private final JLabel[][] grid;
     private final TomatoData data;
@@ -29,12 +28,20 @@ public class CharacterExaltGUI extends JPanel {
         JScrollPane spLeft = new JScrollPane(left);
         JScrollPane spRight = new JScrollPane(right);
 
-        spRight.getVerticalScrollBar().setModel(spLeft.getVerticalScrollBar().getModel());
+        spRight
+            .getVerticalScrollBar()
+            .setModel(spLeft.getVerticalScrollBar().getModel());
         spRight.getVerticalScrollBar().setUnitIncrement(9);
 
-        spLeft.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        spRight.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        spRight.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
+        spLeft.setHorizontalScrollBarPolicy(
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+        );
+        spRight.setHorizontalScrollBarPolicy(
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+        );
+        spRight.setVerticalScrollBarPolicy(
+            JScrollPane.VERTICAL_SCROLLBAR_NEVER
+        );
 
         setLayout(new BorderLayout());
         JPanel leftBar = new JPanel();
@@ -59,14 +66,25 @@ public class CharacterExaltGUI extends JPanel {
     }
 
     private void fixTop(JPanel top) {
-        String[] exaltList = {"Life", "Mana", "Atk", "Def", "Spd", "Dex", "Vit", "Wis"};
+        String[] exaltList = {
+            "Life",
+            "Mana",
+            "Atk",
+            "Def",
+            "Spd",
+            "Dex",
+            "Vit",
+            "Wis",
+        };
         top.setLayout(new GridLayout(1, exaltList.length));
 
         for (String ex : exaltList) {
             JLabel exalts = new JLabel(ex);
 
             JPanel p = new JPanel();
-            p.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+            p.setBorder(
+                BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+            );
             p.add(exalts);
             p.setPreferredSize(new Dimension(35, 27));
             top.add(p);
@@ -86,7 +104,9 @@ public class CharacterExaltGUI extends JPanel {
                 classes = new JLabel("Missing");
             }
             JPanel p = new JPanel(new GridBagLayout());
-            p.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+            p.setBorder(
+                BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+            );
             p.setPreferredSize(new Dimension(110, 27));
             p.add(classes);
 
@@ -100,7 +120,9 @@ public class CharacterExaltGUI extends JPanel {
         for (int i = 0; i < charListSize + 2; i++) {
             for (int j = 0; j < 8; j++) {
                 JPanel p = new JPanel();
-                p.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+                p.setBorder(
+                    BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+                );
                 grid[i][j] = new JLabel("-");
                 p.add(grid[i][j]);
                 right.add(p);
@@ -112,6 +134,7 @@ public class CharacterExaltGUI extends JPanel {
      * Method for receiving realm character list info.
      */
     public static void updateRealmChars() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.update();
     }
 
@@ -119,6 +142,7 @@ public class CharacterExaltGUI extends JPanel {
      * Update exalt tab with exalt stats.
      */
     public static void updateExalts() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.update();
     }
 
@@ -151,6 +175,10 @@ public class CharacterExaltGUI extends JPanel {
     }
 
     private JLabel classIcon(int skin, String classString) {
-        return new JLabel(classString, ImageBuffer.getOutlinedIcon(skin, 15), JLabel.CENTER);
+        return new JLabel(
+            classString,
+            ImageBuffer.getOutlinedIcon(skin, 15),
+            JLabel.CENTER
+        );
     }
 }

--- a/src/main/java/tomato/gui/character/CharacterListGUI.java
+++ b/src/main/java/tomato/gui/character/CharacterListGUI.java
@@ -151,6 +151,7 @@ public class CharacterListGUI extends JPanel {
      * Method for receiving realm character list info.
      */
     public static void updateRealmChars() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.updateCharPanel();
     }
 

--- a/src/main/java/tomato/gui/character/CharacterPanelGUI.java
+++ b/src/main/java/tomato/gui/character/CharacterPanelGUI.java
@@ -10,6 +10,9 @@ import tomato.backend.data.TomatoData;
  */
 public class CharacterPanelGUI extends JPanel {
 
+    // Flag to enable/disable the Characters tab functionality
+    private static final boolean ENABLED = false; // Set to true to re-enable
+
     static final int CHAR_PANEL_SIZE = 120;
 
     public CharacterPanelGUI(TomatoData data) {
@@ -119,6 +122,7 @@ public class CharacterPanelGUI extends JPanel {
      * Vault update method called when receiving vault packets.
      */
     public static void vaultDataUpdate() {
+        if (!ENABLED) return; // Tab is disabled
         CharacterStatMaxingGUI.vaultDataUpdate();
     }
 
@@ -126,6 +130,7 @@ public class CharacterPanelGUI extends JPanel {
      * Method for receiving realm character list info.
      */
     public static void updateRealmChars() {
+        if (!ENABLED) return; // Tab is disabled
         CharacterListGUI.updateRealmChars();
         CharacterStatsGUI.updateRealmChars();
         CharacterExaltGUI.updateRealmChars();

--- a/src/main/java/tomato/gui/character/CharacterPetsGUI.java
+++ b/src/main/java/tomato/gui/character/CharacterPetsGUI.java
@@ -86,6 +86,7 @@ public class CharacterPetsGUI extends JPanel {
     }
 
     public static void addPet(ObjectData object) {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.add(object);
     }
 
@@ -156,11 +157,13 @@ public class CharacterPetsGUI extends JPanel {
     }
 
     public static void clearPets() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.petList.clear();
         INSTANCE.petPanel.removeAll();
     }
 
     public static void updateEquipedPet() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.addPacketPet();
     }
 

--- a/src/main/java/tomato/gui/character/CharacterStatMaxingGUI.java
+++ b/src/main/java/tomato/gui/character/CharacterStatMaxingGUI.java
@@ -1,19 +1,19 @@
 package tomato.gui.character;
 
 import assets.ImageBuffer;
-import tomato.backend.data.VaultData;
-import tomato.realmshark.RealmCharacter;
-import tomato.backend.data.TomatoData;
-import tomato.realmshark.enums.CharacterClass;
-import tomato.realmshark.enums.StatPotion;
-
-import javax.swing.*;
 import java.awt.*;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import javax.swing.*;
+import tomato.backend.data.TomatoData;
+import tomato.backend.data.VaultData;
+import tomato.realmshark.RealmCharacter;
+import tomato.realmshark.enums.CharacterClass;
+import tomato.realmshark.enums.StatPotion;
 
 public class CharacterStatMaxingGUI extends JPanel {
+
     private static CharacterStatMaxingGUI INSTANCE;
 
     private final JLabel[] potStatLabels = new JLabel[8];
@@ -54,6 +54,7 @@ public class CharacterStatMaxingGUI extends JPanel {
      * Method for receiving realm character list info.
      */
     public static void updateRealmChars() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.updateSelection();
         INSTANCE.updateMaxingPanel();
     }
@@ -78,6 +79,7 @@ public class CharacterStatMaxingGUI extends JPanel {
      * Vault update method called when receiving vault packets.
      */
     public static void vaultDataUpdate() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.updateMissingPotsPanel();
         INSTANCE.updateSelection();
     }
@@ -92,10 +94,16 @@ public class CharacterStatMaxingGUI extends JPanel {
 
         maxingPanel.add(Box.createVerticalGlue());
         for (RealmCharacter c : data.chars) {
-            if ((c.seasonal && seasonalRadio.isSelected()) || (!c.seasonal && regularRadio.isSelected())) {
+            if (
+                (c.seasonal && seasonalRadio.isSelected()) ||
+                (!c.seasonal && regularRadio.isSelected())
+            ) {
                 int maxedStats = statsMaxed(c);
                 if (maxedStats != 8) {
-                    JPanel boxChars = createPanelCharWithMissingStats(c, maxedStats);
+                    JPanel boxChars = createPanelCharWithMissingStats(
+                        c,
+                        maxedStats
+                    );
                     maxingPanel.add(boxChars);
                 }
             }
@@ -108,8 +116,12 @@ public class CharacterStatMaxingGUI extends JPanel {
      * Computes the missing pots needed to max the character.
      */
     public static void statMissing(RealmCharacter c, int[] missing) {
-        missing[0] += (int) Math.ceil((CharacterClass.getLife(c.classNum) - c.hp) / 5.0);
-        missing[1] += (int) Math.ceil((CharacterClass.getMana(c.classNum) - c.mp) / 5.0);
+        missing[0] += (int) Math.ceil(
+            (CharacterClass.getLife(c.classNum) - c.hp) / 5.0
+        );
+        missing[1] += (int) Math.ceil(
+            (CharacterClass.getMana(c.classNum) - c.mp) / 5.0
+        );
         missing[2] += CharacterClass.getAtk(c.classNum) - c.atk;
         missing[3] += CharacterClass.getDef(c.classNum) - c.def;
         missing[4] += CharacterClass.getSpd(c.classNum) - c.spd;
@@ -140,7 +152,9 @@ public class CharacterStatMaxingGUI extends JPanel {
      */
     private JPanel missingPotsPanel() {
         JPanel boxPots = CharacterPanelGUI.createMainBox();
-        boxPots.setPreferredSize(new Dimension(390, CharacterPanelGUI.CHAR_PANEL_SIZE));
+        boxPots.setPreferredSize(
+            new Dimension(390, CharacterPanelGUI.CHAR_PANEL_SIZE)
+        );
         boxPots.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
         JPanel panelLeft = CharacterPanelGUI.createLeftBox();
         panelLeft.add(Box.createVerticalGlue());
@@ -162,15 +176,51 @@ public class CharacterStatMaxingGUI extends JPanel {
         JPanel panelTop = new JPanel();
         JPanel panelMid = new JPanel();
         JPanel panelBot = new JPanel();
-        JPanel rightPotDisplay = CharacterPanelGUI.createMidRightBox(panelTop, panelMid, panelBot);
-        potStatLabels[0] = new JLabel("0", getImageIcon(StatPotion.Life), JLabel.CENTER);
-        potStatLabels[1] = new JLabel("0", getImageIcon(StatPotion.Mana), JLabel.CENTER);
-        potStatLabels[2] = new JLabel("0", getImageIcon(StatPotion.Attack), JLabel.CENTER);
-        potStatLabels[3] = new JLabel("0", getImageIcon(StatPotion.Defense), JLabel.CENTER);
-        potStatLabels[4] = new JLabel("0", getImageIcon(StatPotion.Speed), JLabel.CENTER);
-        potStatLabels[5] = new JLabel("0", getImageIcon(StatPotion.Dexterity), JLabel.CENTER);
-        potStatLabels[6] = new JLabel("0", getImageIcon(StatPotion.Vitality), JLabel.CENTER);
-        potStatLabels[7] = new JLabel("0", getImageIcon(StatPotion.Wisdom), JLabel.CENTER);
+        JPanel rightPotDisplay = CharacterPanelGUI.createMidRightBox(
+            panelTop,
+            panelMid,
+            panelBot
+        );
+        potStatLabels[0] = new JLabel(
+            "0",
+            getImageIcon(StatPotion.Life),
+            JLabel.CENTER
+        );
+        potStatLabels[1] = new JLabel(
+            "0",
+            getImageIcon(StatPotion.Mana),
+            JLabel.CENTER
+        );
+        potStatLabels[2] = new JLabel(
+            "0",
+            getImageIcon(StatPotion.Attack),
+            JLabel.CENTER
+        );
+        potStatLabels[3] = new JLabel(
+            "0",
+            getImageIcon(StatPotion.Defense),
+            JLabel.CENTER
+        );
+        potStatLabels[4] = new JLabel(
+            "0",
+            getImageIcon(StatPotion.Speed),
+            JLabel.CENTER
+        );
+        potStatLabels[5] = new JLabel(
+            "0",
+            getImageIcon(StatPotion.Dexterity),
+            JLabel.CENTER
+        );
+        potStatLabels[6] = new JLabel(
+            "0",
+            getImageIcon(StatPotion.Vitality),
+            JLabel.CENTER
+        );
+        potStatLabels[7] = new JLabel(
+            "0",
+            getImageIcon(StatPotion.Wisdom),
+            JLabel.CENTER
+        );
         panelTop.add(Box.createHorizontalGlue());
         panelTop.add(potStatLabels[0]);
         panelTop.add(Box.createHorizontalGlue());
@@ -232,7 +282,9 @@ public class CharacterStatMaxingGUI extends JPanel {
     private void updateMissingPotsPanel() {
         int[] totalPots = new int[8];
         boolean seasonalSelected = seasonalRadio.isSelected();
-        VaultData vaultData = seasonalSelected ? data.seasonalVault : data.regularVault;
+        VaultData vaultData = seasonalSelected
+            ? data.seasonalVault
+            : data.regularVault;
         if (vaultData != null) {
             if (charInvs.isSelected()) {
                 vaultData.getPlayerInvPots(totalPots);
@@ -265,7 +317,10 @@ public class CharacterStatMaxingGUI extends JPanel {
     /**
      * Individual characters in the max stat character list with their stats and what is missing.
      */
-    private JPanel createPanelCharWithMissingStats(RealmCharacter c, int maxedStats) {
+    private JPanel createPanelCharWithMissingStats(
+        RealmCharacter c,
+        int maxedStats
+    ) {
         JPanel boxChars = CharacterPanelGUI.createMainBox();
         JPanel panelLeft = CharacterPanelGUI.createLeftBox();
         boxChars.add(statMaxingChar(panelLeft, c, maxedStats));
@@ -273,7 +328,9 @@ public class CharacterStatMaxingGUI extends JPanel {
         JPanel panelTop = new JPanel();
         JPanel panelMid = new JPanel();
         JPanel panelBot = new JPanel();
-        boxChars.add(CharacterPanelGUI.createMidRightBox(panelTop, panelMid, panelBot));
+        boxChars.add(
+            CharacterPanelGUI.createMidRightBox(panelTop, panelMid, panelBot)
+        );
         statMaxingStats(c, panelTop, panelMid, panelBot);
         return boxChars;
     }
@@ -282,7 +339,11 @@ public class CharacterStatMaxingGUI extends JPanel {
      * Individual characters in the max stat character list
      * with icons and basic info with a selection checkbox.
      */
-    private JPanel statMaxingChar(JPanel panel, RealmCharacter character, int maxedStats) {
+    private JPanel statMaxingChar(
+        JPanel panel,
+        RealmCharacter character,
+        int maxedStats
+    ) {
         panel.add(Box.createVerticalGlue());
         JLabel seasonalLabel = new JLabel(character.seasonal ? "Seasonal" : "");
         seasonalLabel.setForeground(Color.cyan);
@@ -290,14 +351,19 @@ public class CharacterStatMaxingGUI extends JPanel {
         panel.add(seasonalLabel);
         int eq = character.skin;
         if (eq == 0) eq = character.classNum;
-        JLabel characterLabel = new JLabel(ImageBuffer.getOutlinedIcon(eq, 30), JLabel.CENTER);
+        JLabel characterLabel = new JLabel(
+            ImageBuffer.getOutlinedIcon(eq, 30),
+            JLabel.CENTER
+        );
         characterLabel.setAlignmentX(JLabel.CENTER_ALIGNMENT);
         panel.add(characterLabel);
-//        JCheckBox checkBox = checkBoxMissingStats(c.classString + " " + c.level);
-        JCheckBox checkBox = new JCheckBox(character.classString + " " + character.level);
+        //        JCheckBox checkBox = checkBoxMissingStats(c.classString + " " + c.level);
+        JCheckBox checkBox = new JCheckBox(
+            character.classString + " " + character.level
+        );
         checkBox.addActionListener(e -> {
             JCheckBox j = (JCheckBox) e.getSource();
-//            Store.INSTANCE.dispatch(new SetCharacter(character.charId, j.isSelected()));
+            //            Store.INSTANCE.dispatch(new SetCharacter(character.charId, j.isSelected()));
             characters.put(character.charId, j.isSelected());
             updateMissingPotsPanel();
         });
@@ -322,13 +388,22 @@ public class CharacterStatMaxingGUI extends JPanel {
      * Checks if character should be computed for maxing if selected.
      */
     private boolean charSelected(RealmCharacter character) {
-        return characters != null && characters.get(character.charId) != null && characters.get(character.charId);
+        return (
+            characters != null &&
+            characters.get(character.charId) != null &&
+            characters.get(character.charId)
+        );
     }
 
     /**
      * Stat maxing character stats to be added on the mid right panel.
      */
-    private void statMaxingStats(RealmCharacter c, JPanel panelTop, JPanel panelMid, JPanel panelBot) {
+    private void statMaxingStats(
+        RealmCharacter c,
+        JPanel panelTop,
+        JPanel panelMid,
+        JPanel panelBot
+    ) {
         int[] missing = new int[8];
         statMissing(c, missing);
 
@@ -360,7 +435,7 @@ public class CharacterStatMaxingGUI extends JPanel {
      */
     private void statLabel(JPanel panel, String name, int stat, int missing) {
         JLabel l = new JLabel();
-//        new JLabel("<html>Text color: <font color='red'>red</font></html>");
+        //        new JLabel("<html>Text color: <font color='red'>red</font></html>");
         String s;
         if (missing != 0) {
             s = String.format(name + ": %d (%d)", stat, missing);

--- a/src/main/java/tomato/gui/character/CharacterStatsGUI.java
+++ b/src/main/java/tomato/gui/character/CharacterStatsGUI.java
@@ -1,11 +1,6 @@
 package tomato.gui.character;
 
 import assets.ImageBuffer;
-import tomato.realmshark.RealmCharacter;
-import tomato.backend.data.TomatoData;
-import tomato.realmshark.enums.CharacterStatistics;
-
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -13,11 +8,16 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Comparator;
+import javax.swing.*;
+import tomato.backend.data.TomatoData;
+import tomato.realmshark.RealmCharacter;
+import tomato.realmshark.enums.CharacterStatistics;
 
 /**
  * Dungeon completion display GUI class showing all dungeon completions of the users account.
  */
 public class CharacterStatsGUI extends JPanel {
+
     private static CharacterStatsGUI INSTANCE;
     private final JPanel left, right;
     private final int dungeonCount;
@@ -40,16 +40,26 @@ public class CharacterStatsGUI extends JPanel {
         JScrollPane spLeft = new JScrollPane(left);
         JScrollPane spRight = new JScrollPane(right);
 
-        spRight.getHorizontalScrollBar().setModel(spTop.getHorizontalScrollBar().getModel());
-        spRight.getVerticalScrollBar().setModel(spLeft.getVerticalScrollBar().getModel());
+        spRight
+            .getHorizontalScrollBar()
+            .setModel(spTop.getHorizontalScrollBar().getModel());
+        spRight
+            .getVerticalScrollBar()
+            .setModel(spLeft.getVerticalScrollBar().getModel());
         spTop.getHorizontalScrollBar().setUnitIncrement(3);
         spRight.getVerticalScrollBar().setUnitIncrement(9);
 
-        spLeft.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        spLeft.setHorizontalScrollBarPolicy(
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+        );
         spLeft.getVerticalScrollBar().setUnitIncrement(9);
 
-        spRight.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        spRight.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
+        spRight.setHorizontalScrollBarPolicy(
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+        );
+        spRight.setVerticalScrollBarPolicy(
+            JScrollPane.VERTICAL_SCROLLBAR_NEVER
+        );
         spTop.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
 
         setLayout(new BorderLayout());
@@ -62,18 +72,20 @@ public class CharacterStatsGUI extends JPanel {
         topLeft.setPreferredSize(new Dimension(37, 37));
         topLeftLabel = new JLabel(getImageIcon(810), JLabel.CENTER);
         topLeft.add(topLeftLabel);
-        topLeftLabel.addMouseListener(new MouseAdapter() {
-            public void mouseClicked(MouseEvent e) {
-                if (data.chars == null) return;
-                sortOrder = !sortOrder;
-                if (sortOrder) {
-                    data.chars.sort(Comparator.comparingLong(o -> o.fame));
-                } else {
-                    data.chars.sort(Comparator.comparingLong(o -> -o.fame));
+        topLeftLabel.addMouseListener(
+            new MouseAdapter() {
+                public void mouseClicked(MouseEvent e) {
+                    if (data.chars == null) return;
+                    sortOrder = !sortOrder;
+                    if (sortOrder) {
+                        data.chars.sort(Comparator.comparingLong(o -> o.fame));
+                    } else {
+                        data.chars.sort(Comparator.comparingLong(o -> -o.fame));
+                    }
+                    update();
                 }
-                update();
             }
-        });
+        );
 
         leftBar.add(topLeft, BorderLayout.NORTH);
         leftBar.add(spLeft, BorderLayout.CENTER);
@@ -102,25 +114,40 @@ public class CharacterStatsGUI extends JPanel {
             int id = CharacterStatistics.DUNGEONS.get(j);
             name = CharacterStatistics.getName(id);
 
-            JLabel dungeonIcon = new JLabel(ImageBuffer.getOutlinedIcon(id, 15), JLabel.CENTER);
+            JLabel dungeonIcon = new JLabel(
+                ImageBuffer.getOutlinedIcon(id, 15),
+                JLabel.CENTER
+            );
             dungeonIcon.setToolTipText(name);
 
             int finalJ = j;
-            dungeonIcon.addMouseListener(new MouseAdapter() {
-                public void mouseClicked(MouseEvent e) {
-                    if (data.chars == null) return;
-                    sortOrder = !sortOrder;
-                    if (sortOrder) {
-                        data.chars.sort(Comparator.comparingLong(o -> -o.charStats.dungeonStats[finalJ]));
-                    } else {
-                        data.chars.sort(Comparator.comparingLong(o -> o.charStats.dungeonStats[finalJ]));
+            dungeonIcon.addMouseListener(
+                new MouseAdapter() {
+                    public void mouseClicked(MouseEvent e) {
+                        if (data.chars == null) return;
+                        sortOrder = !sortOrder;
+                        if (sortOrder) {
+                            data.chars.sort(
+                                Comparator.comparingLong(o ->
+                                    -o.charStats.dungeonStats[finalJ]
+                                )
+                            );
+                        } else {
+                            data.chars.sort(
+                                Comparator.comparingLong(o ->
+                                    o.charStats.dungeonStats[finalJ]
+                                )
+                            );
+                        }
+                        update();
                     }
-                    update();
                 }
-            });
+            );
 
             JPanel p = new JPanel();
-            p.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+            p.setBorder(
+                BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+            );
             p.add(dungeonIcon);
             p.setPreferredSize(new Dimension(35, 37));
             top.add(p);
@@ -131,6 +158,7 @@ public class CharacterStatsGUI extends JPanel {
      * Method for receiving realm character list info.
      */
     public static void updateRealmChars() {
+        if (INSTANCE == null) return; // Tab is disabled
         INSTANCE.update();
     }
 
@@ -180,7 +208,9 @@ public class CharacterStatsGUI extends JPanel {
             RealmCharacter c = data.chars.get(i);
             JLabel player = playerIcon(c);
             JPanel p = new JPanel(new GridBagLayout());
-            p.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+            p.setBorder(
+                BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+            );
             p.setPreferredSize(new Dimension(150, 27));
             p.add(player);
 
@@ -207,7 +237,9 @@ public class CharacterStatsGUI extends JPanel {
             for (int j = 0; j < dungeonCount; j++) {
                 int v = c.charStats.dungeonStats[j];
                 JPanel p2 = new JPanel();
-                p2.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray));
+                p2.setBorder(
+                    BorderFactory.createMatteBorder(0, 0, 1, 1, Color.gray)
+                );
                 labels[i][j] = new JLabel("" + v);
                 p2.add(labels[i][j]);
                 p2.setPreferredSize(new Dimension(35, 27));
@@ -227,23 +259,29 @@ public class CharacterStatsGUI extends JPanel {
             int eq = c.skin;
             if (eq == 0) eq = c.classNum;
             ImageIcon icon = getImageIcon(eq);
-            JLabel characterLabel = new JLabel(c.classString + " " + c.fame, icon, JLabel.CENTER);
-            characterLabel.addMouseListener(new MouseAdapter() {
-                public void mouseClicked(MouseEvent e) {
-                    if (data.chars == null) return;
-                    boolean b = data.chars.remove(c);
-                    if (b) {
-                        data.chars.add(0, c);
+            JLabel characterLabel = new JLabel(
+                c.classString + " " + c.fame,
+                icon,
+                JLabel.CENTER
+            );
+            characterLabel.addMouseListener(
+                new MouseAdapter() {
+                    public void mouseClicked(MouseEvent e) {
+                        if (data.chars == null) return;
+                        boolean b = data.chars.remove(c);
+                        if (b) {
+                            data.chars.add(0, c);
+                        }
+                        //                    sortOrder = !sortOrder;
+                        //                    if (sortOrder) {
+                        //                        data.chars.sort(Comparator.comparingLong(o -> -o.fame));
+                        //                    } else {
+                        //                        data.chars.sort(Comparator.comparingLong(o -> o.fame));
+                        //                    }
+                        update();
                     }
-//                    sortOrder = !sortOrder;
-//                    if (sortOrder) {
-//                        data.chars.sort(Comparator.comparingLong(o -> -o.fame));
-//                    } else {
-//                        data.chars.sort(Comparator.comparingLong(o -> o.fame));
-//                    }
-                    update();
                 }
-            });
+            );
             return characterLabel;
         } catch (Exception e) {
             e.printStackTrace();
@@ -265,29 +303,42 @@ public class CharacterStatsGUI extends JPanel {
      * Horizontal scroll class
      */
     class HorizontalJScrollPane extends JScrollPane {
+
         public HorizontalJScrollPane(Component component) {
             super(component);
             final JScrollBar horizontalScrollBar = getHorizontalScrollBar();
             setWheelScrollingEnabled(false);
-            addMouseWheelListener(new MouseAdapter() {
-                public void mouseWheelMoved(MouseWheelEvent evt) {
-
-                    int iScrollAmount = horizontalScrollBar.getUnitIncrement();
-                    if (evt.getWheelRotation() >= 1)//mouse wheel was rotated down/ towards the user
-                    {
-                        int iNewValue = horizontalScrollBar.getValue() + horizontalScrollBar.getBlockIncrement() * iScrollAmount * Math.abs(evt.getWheelRotation());
-                        if (iNewValue <= horizontalScrollBar.getMaximum()) {
-                            horizontalScrollBar.setValue(iNewValue);
-                        }
-                    } else if (evt.getWheelRotation() <= -1)//mouse wheel was rotated up/away from the user
-                    {
-                        int iNewValue = horizontalScrollBar.getValue() - horizontalScrollBar.getBlockIncrement() * iScrollAmount * Math.abs(evt.getWheelRotation());
-                        if (iNewValue >= 0) {
-                            horizontalScrollBar.setValue(iNewValue);
+            addMouseWheelListener(
+                new MouseAdapter() {
+                    public void mouseWheelMoved(MouseWheelEvent evt) {
+                        int iScrollAmount =
+                            horizontalScrollBar.getUnitIncrement();
+                        if (
+                            evt.getWheelRotation() >= 1 //mouse wheel was rotated down/ towards the user
+                        ) {
+                            int iNewValue =
+                                horizontalScrollBar.getValue() +
+                                horizontalScrollBar.getBlockIncrement() *
+                                iScrollAmount *
+                                Math.abs(evt.getWheelRotation());
+                            if (iNewValue <= horizontalScrollBar.getMaximum()) {
+                                horizontalScrollBar.setValue(iNewValue);
+                            }
+                        } else if (
+                            evt.getWheelRotation() <= -1 //mouse wheel was rotated up/away from the user
+                        ) {
+                            int iNewValue =
+                                horizontalScrollBar.getValue() -
+                                horizontalScrollBar.getBlockIncrement() *
+                                iScrollAmount *
+                                Math.abs(evt.getWheelRotation());
+                            if (iNewValue >= 0) {
+                                horizontalScrollBar.setValue(iNewValue);
+                            }
                         }
                     }
                 }
-            });
+            );
         }
     }
 }

--- a/src/main/java/tomato/gui/dps/shared/EquipmentUsageAggregator.java
+++ b/src/main/java/tomato/gui/dps/shared/EquipmentUsageAggregator.java
@@ -147,17 +147,8 @@ public final class EquipmentUsageAggregator {
                 final int fi = i;
                 SlotUsage su = ou.slots[fi];
 
-                // Prefer damage-time ability item for slot 1 attribution.
-                // If Damage.ownerAbilityItem is set (not -1), use it for slot index 1.
-                // Otherwise, fall back to the inventory snapshot stored on the Damage.
-                int itemId;
-                if (fi == 1) {
-                    itemId = (d.ownerAbilityItem != -1)
-                        ? d.ownerAbilityItem
-                        : d.ownerInvntory[fi];
-                } else {
-                    itemId = d.ownerInvntory[fi];
-                }
+                // Use inventory snapshot stored on the Damage
+                int itemId = d.ownerInvntory[fi];
 
                 // Ensure Equipment.totalDmg points to the slot total accumulator.
                 Equipment eq = su.items.computeIfAbsent(itemId, id ->

--- a/src/test/java/experimental/DpsLogger.java
+++ b/src/test/java/experimental/DpsLogger.java
@@ -118,15 +118,27 @@ public class DpsLogger {
             );
         } else if (packet instanceof DamagePacket) {
             DamagePacket p = (DamagePacket) packet;
+
+            /*
+             * DAMAGEPACKET HANDLING:
+             * DamagePacket contains direct damage information without needing to resolve
+             * projectiles from bulletId. The attacker entity (p.objectId) is ensured to
+             * exist via getEntity() which will create it if not already in entityList.
+             * This ensures proper damage attribution even for non-player entities.
+             */
             if (p.damageAmount > 0) {
                 Bullet bullet = new Bullet(packet);
                 bullet.totalDmg = p.damageAmount;
+
                 Entity entity = getEntity(p.targetId);
+
+                // Ensure attacker entity exists in entityList for proper damage attribution
+                Entity attacker = getEntity(p.objectId);
+
                 hit(entity, bullet, p);
-                if (!entityHitList.containsKey(entity.id)) entityHitList.put(
-                    entity.id,
-                    entity
-                );
+                if (!entityHitList.containsKey(entity.id)) {
+                    entityHitList.put(entity.id, entity);
+                }
             }
         } else if (packet instanceof NewTickPacket) {
             NewTickPacket p = (NewTickPacket) packet;
@@ -291,8 +303,20 @@ public class DpsLogger {
                     DamagePacket p = (DamagePacket) b.packet;
                     int ownerId = p.objectId;
                     Entity owner = entityList.get(ownerId);
-                    if (owner == null) continue;
-                    if (owner.stats[31] == null) continue;
+
+                    if (owner == null) {
+                        continue;
+                    }
+
+                    String ownerName =
+                        owner.stats[31] != null
+                            ? owner.stats[31].stringStatValue
+                            : null;
+
+                    if (owner.stats[31] == null) {
+                        continue;
+                    }
+
                     damagerList.put(ownerId, owner);
                     addDamage(dmgList, b, p.damageAmount, owner);
                 } else if (b.packet instanceof EnemyHitPacket) {
@@ -634,15 +658,12 @@ public class DpsLogger {
             // Weapon projectile: calculate damage client-side with defense
             int[] conditions = new int[2];
 
-            conditions[0] = entity.getStat(29) == null
-                ? 0
-                : entity.getStat(29).statValue;
-            conditions[1] = entity.getStat(96) == null
-                ? 0
-                : entity.getStat(96).statValue;
-            int defence = entity.getStat(21) == null
-                ? 0
-                : entity.getStat(21).statValue;
+            conditions[0] =
+                entity.getStat(29) == null ? 0 : entity.getStat(29).statValue;
+            conditions[1] =
+                entity.getStat(96) == null ? 0 : entity.getStat(96).statValue;
+            int defence =
+                entity.getStat(21) == null ? 0 : entity.getStat(21).statValue;
 
             Bullet b = new Bullet(packet);
             b.totalDmg = damageWithDefense(


### PR DESCRIPTION
Remove unused defense-ignore fields from AbilityScalingData and simplify scaling construction. Add ownerObjectType and ownerObjectName to Damage and a minionOwnerMap to TomatoData to improve attribution for necro summons.
Ensure attacker entities exist when handling
DamagePacket. Disable the Characters tab and guard related GUI calls. Misc minor cleanups (remove debug println, import/format tweaks).