### PR TITLE
1.9.1 Hotfix - Asset Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ hs_err_pid*
 # Misc files
 realmShark.properties
 .DS_Store
+/FameSessions/

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-project.version = 'v1.2.1'
+project.version = 'v1.2.2'
 applicationName = 'RealmShark'
 
 project.ext.lwjglVersion = "3.3.1"

--- a/src/main/java/assets/AssetExtractor.java
+++ b/src/main/java/assets/AssetExtractor.java
@@ -52,9 +52,25 @@ public class AssetExtractor {
     private static JOptionPane pane;
 
     static {
-        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("mac")) {
             REALM_RES_PATH =
-                "RealmOfTheMadGod/Production/RotMGExalt.app/Contents/Resources/Data/resources.assets";
+                System.getProperty("user.home") +
+                    "/.local/share/RealmOfTheMadGod/Production/RotMGExalt.app/Contents/Resources/Data/resources.assets";
+        } else if (os.contains("win")) {
+            String localAppData = System.getenv("LOCALAPPDATA");
+            if (localAppData != null) {
+                REALM_RES_PATH =
+                        localAppData +
+                                "/RealmOfTheMadGod/Production/RotMG Exalt_Data/resources.assets";
+
+                // Fallback for older installations
+                File testFile = new File(REALM_RES_PATH);
+                if (!testFile.exists()) {
+                    REALM_RES_PATH =
+                            "RealmOfTheMadGod/Production/RotMG Exalt_Data/resources.assets";
+                }
+            }
         } else {
             REALM_RES_PATH =
                 "RealmOfTheMadGod/Production/RotMG Exalt_Data/resources.assets";
@@ -283,7 +299,6 @@ public class AssetExtractor {
             if (Paths.get(REALM_RES_PATH).isAbsolute()) {
                 defaultFile = new File(REALM_RES_PATH);
             } else {
-//                String homeDir = System.getProperty("user.home");
                 String homeDir = FileSystemView.getFileSystemView().getDefaultDirectory().getAbsolutePath();
                 Path defaultPath = Paths.get(homeDir, REALM_RES_PATH);
                 defaultFile = defaultPath.toFile();

--- a/src/main/java/realmshark/version/Version.java
+++ b/src/main/java/realmshark/version/Version.java
@@ -3,6 +3,6 @@ package realmshark.version;
  * Don't edit this class. It's a gradle class to grab version from the build.gradle
  */
 public class Version {
-    public static final String VERSION = "v1.2.1";
+    public static final String VERSION = "v1.2.2";
 }
 


### PR DESCRIPTION
Includes fixes for the new asset paths released by DECA
- macOS now uses `~/.local/share/RealmOfTheMadGod/Production/RotMGExalt.app/Contents/Resources/Data/resources.assets`
- windows now uses `%LOCALAPPDATA%/RealmOfTheMadGod/Production/RotMG Exalt_Data/resources.assets`
   - this falls back to the old path if it does not exist
- linux still uses the same path because I have no idea what the linux path is

Also includes:
- hotfix version bump
- small `.gitignore` update