### PR TITLE
1.9.1 Hotfix - Tomato Version Bump + Character Tab Re-enablement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ hs_err_pid*
 # Misc files
 realmShark.properties
 .DS_Store
+/FameSessions/

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ In the future, OS specific functionality will be added to support multiple insta
 
 ## Install guide
 
-MAC support is not available right now. It will be added in a future version.
+If there are errors running the program described below, please check the [Discord](https://discord.gg/msKrWSD4Mf), the troubleshooting section below, or [open an issue here,](https://github.com/X-com/RealmShark/issues) so it can be resolved.
 
-For Windows:
+### For Windows:
 
 1. Java and Npcap is required for running the program. Java can be downloaded from [here](https://www.java.com/en/download/) and Npcap from [here](https://npcap.com/#download). Open the files one at a time and follow the install instructions for both.
 
@@ -35,7 +35,15 @@ For Windows:
 
 4. The RealmShark GUI should open. Start it by clicking File -> Start Sniffer. All chat in the game should appear in the Chat tab.
 
-If there are errors running the program described above, please look under Trouble shooting guide or [open an issue here,](https://github.com/X-com/RealmShark/issues) so it can be resolved.
+### For Mac:
+All the steps are the same, but in order to enable packet capture for the non-root user, you may need to run:
+`sudo chown $(whoami):admin /dev/bpf*`
+
+### For Linux:
+Linux is not officially supported, but many users have had success. Steam is the standardized client for Linux; other installations may not work as expected. If you run into issues, try:
+
+- Run from command line using the `--path <custom-path>` argument.
+- Ask for help in the Discord.
 
 ## Troubleshooting guide
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-project.version = 'v1.9.0'
+project.version = 'v1.9.1'
 applicationName = 'Tomato'
 
 project.ext.lwjglVersion = "3.3.1"
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation files("libs/RealmShark-v1.2.1.jar")
+    implementation files("libs/RealmShark-v1.2.2.jar")
     implementation 'com.github.weisj:darklaf-core:3.0.2'
     implementation 'org.java-websocket:Java-WebSocket:1.5.3'
     runtimeOnly 'org.slf4j:slf4j-nop:2.0.17'

--- a/src/main/java/tomato/CheckVersion.java
+++ b/src/main/java/tomato/CheckVersion.java
@@ -24,7 +24,7 @@ public class CheckVersion {
         conn.setRequestProperty("Accept", "application/vnd.github.v3+json");
 
         if (conn.getResponseCode() != 200) {
-            throw new RuntimeException("Failed : HTTP error code : " + conn.getResponseCode());
+            throw new IOException("Failed : HTTP error code : " + conn.getResponseCode());
         }
 
         BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
@@ -70,6 +70,7 @@ public class CheckVersion {
         try {
             return getLatestVersion().equals(Version.VERSION);
         } catch (IOException ignored) {
+            // If we can't check the version, assume it's the latest to avoid bothering the user
         }
         return true;
     }

--- a/src/main/java/tomato/Tomato.java
+++ b/src/main/java/tomato/Tomato.java
@@ -48,6 +48,8 @@ public class Tomato {
                 System.getProperty("sun.arch.data.model") +
                 " - bit)"
         );
+        parseArgs(args);
+
         parseCustomAssetPath(args);
 
         parseCustomAssetPath(args);
@@ -63,6 +65,26 @@ public class Tomato {
         initializeCrucibleData();
 
         load();
+    }
+
+    private static void parseArgs(String[] args) {
+        for (String arg : args) {
+            if (arg.equals("--help") || arg.equals("-h")) {
+                usage();
+                System.exit(0);
+            }
+        }
+
+        parseCustomAssetPath(args);
+    }
+
+    private static void usage() {
+        System.out.println("Usage: java -jar Tomato.jar [options]");
+        System.out.println("Options:");
+        System.out.println("  --help, -h          Show this help message");
+        System.out.println(
+            "  --path <file_path>  Specify custom resources.assets file path"
+        );
     }
 
     /**

--- a/src/main/java/tomato/gui/TomatoGUI.java
+++ b/src/main/java/tomato/gui/TomatoGUI.java
@@ -67,9 +67,8 @@ public class TomatoGUI {
         securityPanel = new SecurityGUI();
         tabbedPane.addTab("Security", securityPanel);
 
-        // Temporarily disabled - non-functional
-        // characterPanel = new CharacterPanelGUI(data);
-        // tabbedPane.addTab("Characters", characterPanel);
+        characterPanel = new CharacterPanelGUI(data);
+        tabbedPane.addTab("Characters", characterPanel);
 
         statistics = new StatisticsGUI(data);
         tabbedPane.addTab("Statistics", statistics);

--- a/src/main/java/tomato/gui/character/CharacterPanelGUI.java
+++ b/src/main/java/tomato/gui/character/CharacterPanelGUI.java
@@ -33,11 +33,11 @@ public class CharacterPanelGUI extends JPanel {
 
         JTabbedPane tabbedPane = new JTabbedPane();
         add(tabbedPane);
-        tabbedPane.addTab("Characters", charListPanel);
-        tabbedPane.addTab("Statistics", characterStatsGUI);
-        tabbedPane.addTab("Collections", characterCollectionGUI);
+        // tabbedPane.addTab("Characters", charListPanel);
+        // tabbedPane.addTab("Statistics", characterStatsGUI);
+        // tabbedPane.addTab("Collections", characterCollectionGUI);
         tabbedPane.addTab("Exalts", exalts);
-        tabbedPane.addTab("Stat Maxing", mainMaxingPanel);
+        // tabbedPane.addTab("Stat Maxing", mainMaxingPanel);
         tabbedPane.addTab("Pets", characterPetsGUI);
 
         //        JButton button = new JButton("Test");

--- a/src/main/java/tomato/version/Version.java
+++ b/src/main/java/tomato/version/Version.java
@@ -3,6 +3,6 @@ package tomato.version;
  * Don't edit this class. It's a gradle class to grab version from the build.gradle
  */
 public class Version {
-    public static final String VERSION = "v1.8.4";
+    public static final String VERSION = "v1.9.1";
 }
 


### PR DESCRIPTION
This pull request re-enables the `Characters` tab in the main GUI and updates the application version. Additionally, it adjusts which sub-tabs are visible within the `CharacterPanelGUI`, focusing on specific features.

User interface updates:

* The `Characters` tab is now enabled in the main `TomatoGUI`, allowing users to access character-related features.
* Within `CharacterPanelGUI`, only the `Exalts` and `Pets` sub-tabs are shown; other character-related sub-tabs such as `Characters`, `Statistics`, `Collections`, and `Stat Maxing` remain disabled for now.

Version update:

* The application version is updated from `v1.8.4` to `v1.9.1` in `Version.java`.

Various fixes:
* Fixed an issue where if GitHub was not available, Tomato would fail to launch