### PR TITLE
Update CharacterClass

### DIFF
--- a/src/main/java/tomato/backend/SecurityAbilityUseCheck.java
+++ b/src/main/java/tomato/backend/SecurityAbilityUseCheck.java
@@ -87,7 +87,8 @@ public class SecurityAbilityUseCheck {
     }
 
     public static void checkManaFromDecoyUsed(Entity entity, StatData[] stats) {
-        if (entity.objectType != CharacterClass.Trickster.getId()) return; // check if trickster
+        if (CharacterClass.isPlayerCharacter(entity.objectType)
+                && !CharacterClass.getName(entity.objectType).equals("Trickster")) return;
         if (decoyCounter == 0) {
             for (StatData sd : stats) {
                 if (sd.statType == StatType.MP_STAT) {

--- a/src/main/java/tomato/realmshark/enums/CharacterClass.java
+++ b/src/main/java/tomato/realmshark/enums/CharacterClass.java
@@ -1,8 +1,5 @@
 package tomato.realmshark.enums;
 
-import java.util.TreeMap;
-import java.util.TreeSet;
-
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
@@ -11,65 +8,26 @@ import java.util.stream.Collectors;
 
 import util.StringXML;
 
-/**
- * Character class enum to get class name and stats from class id.
- */
-public enum CharacterClass {
-    Rogue(768, 750, 252, 55, 25, 65, 75, 40, 50, new int[]{768, 800, 804}),
-    Archer(775, 750, 252, 75, 25, 55, 50, 40, 50, new int[]{775, 802, 796}),
-    Wizard(782, 700, 385, 75, 25, 50, 75, 40, 60, new int[]{782, 801, 803}),
-    Priest(784, 700, 385, 55, 25, 55, 60, 40, 75, new int[]{784, 805, 817}),
-    Warrior(797, 800, 252, 75, 25, 50, 50, 75, 50, new int[]{797, 798, 799}),
-    Knight(798, 800, 252, 50, 40, 50, 50, 75, 50, new int[]{797, 798, 799}),
-    Paladin(799, 800, 252, 55, 30, 55, 55, 60, 75, new int[]{797, 798, 799}),
-    Assassin(800, 750, 305, 65, 25, 65, 75, 40, 60, new int[]{768, 800, 804}),
-    Necromancer(801, 700, 385, 75, 25, 50, 60, 40, 75, new int[]{782, 801, 803}),
-    Huntress(802, 750, 305, 65, 25, 50, 60, 40, 50, new int[]{775, 802, 796}),
-    Trickster(804, 750, 252, 65, 25, 75, 75, 40, 60, new int[]{768, 800, 804}),
-    Mystic(803, 700, 385, 65, 25, 60, 65, 40, 75, new int[]{782, 801, 803}),
-    Sorcerer(805, 700, 385, 70, 25, 60, 60, 75, 60, new int[]{784, 805, 817}),
-    Ninja(806, 800, 252, 70, 25, 60, 70, 60, 70, new int[]{806, 785, 818}),
-    Samurai(785, 800, 252, 75, 30, 55, 55, 60, 60, new int[]{806, 785, 818}),
-    Bard(796, 750, 385, 55, 25, 55, 70, 45, 75, new int[]{775, 802, 796}),
-    Summoner(817, 700, 385, 60, 25, 60, 75, 40, 75, new int[]{784, 805, 817}),
-    Kensei(818, 800, 252, 65, 25, 60, 65, 60, 50, new int[]{806, 785, 818});
-
+public class CharacterClass {
     private static final String PLAYERS_XML_PATH = "assets/xml/players.xml";
 
-    private int life, mana, atk, def, spd, dex, vit, wis;
-    private final int id;
-    private final int[] weaponGroup;
-    private int[] maxStats;
+    public final int id;
+    public final String name;
+    public final int life;
+    public final int mana;
+    public final int atk;
+    public final int def;
+    public final int spd;
+    public final int dex;
+    public final int vit; // Equivalent to HpRegen
+    public final int wis; // Equivalent to MpRegen
+    public int[] weaponGroup; // Mutable for updating after parsing
+    public final int[] maxStats;
+    public final int[] baseGear;
 
-    public static final CharacterClass[] CHAR_CLASS_LIST;
-    private static final TreeMap<Integer, CharacterClass> CHARACTER_CLASS = new TreeMap<>();
-    private static final TreeMap<Integer, String> CLASS_NAME = new TreeMap<>();
-    private static final TreeMap<Integer, int[]> CLASS_MAX_STATS = new TreeMap<>();
-    private static final TreeMap<Integer, int[]> WEAPON_CLASSES = new TreeMap<>();
-    private static final TreeSet<Integer> CHARACTER_IDS = new TreeSet<>();
-
-    static {
-        CHAR_CLASS_LIST = CharacterClass.values().clone();
-        try {
-            FileInputStream file = new FileInputStream(PLAYERS_XML_PATH);
-            populateFromXML(new BufferedReader(new InputStreamReader(file)).lines().collect(Collectors.joining("\n")));
-
-            for (CharacterClass o : CharacterClass.values()) {
-                o.maxStats = new int[]{o.life, o.mana, o.atk, o.def, o.spd, o.dex, o.vit, o.wis};
-
-                CHARACTER_IDS.add(o.id);
-                CHARACTER_CLASS.put(o.id, o);
-                CLASS_NAME.put(o.id, o.toString());
-                WEAPON_CLASSES.put(o.id, o.weaponGroup);
-                CLASS_MAX_STATS.put(o.id, o.maxStats);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    CharacterClass(int id, int life, int mana, int atk, int def, int spd, int dex, int vit, int wis, int[] weaponGroup) {
+    CharacterClass(int id, String name, int life, int mana, int atk, int def, int spd, int dex, int vit, int wis, int[] weaponGroup, int[] baseGear) {
         this.id = id;
+        this.name = name;
         this.life = life;
         this.mana = mana;
         this.atk = atk;
@@ -79,9 +37,38 @@ public enum CharacterClass {
         this.vit = vit;
         this.wis = wis;
         this.weaponGroup = weaponGroup;
+        maxStats = new int[]{life, mana, atk, def, spd, dex, vit, wis};
+        this.baseGear = baseGear;
     }
 
-    private static void populateFromXML(String rawXML) throws Exception {
+    // Static structures to hold dynamic data
+    public static final CharacterClass[] CHAR_CLASS_LIST;
+    private static final TreeMap<Integer, CharacterClass> CHARACTER_CLASS = new TreeMap<>();
+    private static final TreeMap<Integer, String> CLASS_NAME = new TreeMap<>();
+    private static final TreeMap<Integer, int[]> CLASS_MAX_STATS = new TreeMap<>();
+    private static final TreeMap<Integer, int[]> WEAPON_CLASSES = new TreeMap<>();
+    private static final TreeSet<Integer> CHARACTER_IDS = new TreeSet<>();
+
+    // Static initialization block
+    static {
+        List<CharacterClass> charClassList = new ArrayList<>();
+        try {
+            FileInputStream file = new FileInputStream(PLAYERS_XML_PATH);
+            populateFromXML(new BufferedReader(new InputStreamReader(file)).lines().collect(Collectors.joining("\n")), charClassList);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        CHAR_CLASS_LIST = charClassList.toArray(new CharacterClass[0]);
+        for (CharacterClass o : CHAR_CLASS_LIST) {
+                CHARACTER_IDS.add(o.id);
+                CHARACTER_CLASS.put(o.id, o);
+            CLASS_NAME.put(o.id, o.name);
+                WEAPON_CLASSES.put(o.id, o.weaponGroup);
+                CLASS_MAX_STATS.put(o.id, o.maxStats);
+        }
+    }
+
+    private static void populateFromXML(String rawXML, List<CharacterClass> charClassList) throws Exception {
         // Parse the XML using StringXML
         StringXML root = StringXML.getParsedXML(rawXML);
 
@@ -92,6 +79,7 @@ public enum CharacterClass {
         // Process each Object element
         for (StringXML object : root) {
             if (!object.name.equals("Object")) continue; // Skip non-Object nodes
+
             // Extract id and name
             String name = object.children.stream()
                     .filter(child -> child.name.equals("id"))
@@ -99,71 +87,56 @@ public enum CharacterClass {
                     .findFirst()
                     .orElse(null);
 
-//            int id = object.children.stream()
-//                    .filter(child -> child.name.equals("type"))
-//                    .mapToInt(child -> Integer.decode(child.value))
-//                    .findFirst()
-//                    .orElseThrow(() -> new IllegalArgumentException("Missing type attribute"));
+            int id = object.children.stream()
+                    .filter(child -> child.name.equals("type"))
+                    .mapToInt(child -> Integer.decode(child.value))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Missing type attribute"));
 
-            CharacterClass cc = null;
-            for(CharacterClass o : CharacterClass.CHAR_CLASS_LIST) {
-                if(o.name().equals(name)) {
-                    cc = o;
+            // Extract individual max stats
+            int life = getMaxValue(object, "MaxHitPoints");
+            int mana = getMaxValue(object, "MaxMagicPoints");
+            int atk = getMaxValue(object, "Attack");
+            int def = getMaxValue(object, "Defense");
+            int spd = getMaxValue(object, "Speed");
+            int dex = getMaxValue(object, "Dexterity");
+            int vit = getMaxValue(object, "HpRegen");
+            int wis = getMaxValue(object, "MpRegen");
+
+            // Extract Equipment and determine weapon group
+            String baseEquipmentString = "";
+            for (StringXML child : object.children) {
+                if (child.name.equals("Equipment")) {
+                    for (StringXML stringXML : child.children) {
+                        baseEquipmentString = stringXML.value;
+                        break;
+            }
                     break;
                 }
             }
-            if(cc == null) continue;
+            String[] equipmentItems = baseEquipmentString.split(",");
+            int[] baseGear = new int[4];
+            for (int baseGearIndex = 0; baseGearIndex < 3; baseGearIndex++)
+                baseGear[baseGearIndex] = Integer.decode(equipmentItems[baseGearIndex].trim());
+            baseGear[3] = 2639; // Add ring
+            int weaponId = baseGear[0];
+            weaponGroups.computeIfAbsent(weaponId, k -> new ArrayList<>()).add(id);
+            weaponCharacter.put(id, weaponId);
 
-            // Extract individual max stats
-            int l = updateValue(object, "MaxHitPoints");
-            if (cc.life != l) {
-                cc.life = l;
-            }
-            int m = updateValue(object, "MaxMagicPoints");
-            if (cc.mana != l) cc.mana = m;
-            int a = updateValue(object, "Attack");
-            if (cc.atk != l) cc.atk = a;
-            int df = updateValue(object, "Defense");
-            if (cc.def != l) cc.def = df;
-            int s = updateValue(object, "Speed");
-            if (cc.spd != l) cc.spd = s;
-            int dx = updateValue(object, "Dexterity");
-            if (cc.dex != l) cc.dex = dx;
-            int v = updateValue(object, "HpRegen");
-            if (cc.vit != l) cc.vit = v;
-            int w = updateValue(object, "MpRegen");
-            if (cc.wis != l) cc.wis = w;
-
-//            // Extract Equipment and determine weapon group
-//            String equipment = "";
-//            for (StringXML child : object.children) {
-//                if (child.name.equals("Equipment")) {
-//                    for (StringXML stringXML : child.children) {
-//                        equipment = stringXML.value;
-//                        break;
-//                    }
-//                    break;
-//                }
-//            }
-//            String[] equipmentItems = equipment.split(",");
-//            int weaponId = Integer.decode(equipmentItems[0].trim());
-//            weaponGroups.computeIfAbsent(weaponId, k -> new ArrayList<>()).add(id);
-//            weaponCharacter.put(id, weaponId);
-
-//            // Create CharacterClass instance
-//            charClassList.add(new CharacterClass(id, name, life, mana, atk, def, spd, dex, vit, wis, new int[0])); // Weapon group will be set later
+            // Create CharacterClass instance
+            charClassList.add(new CharacterClass(id, name, life, mana, atk, def, spd, dex, vit, wis, new int[0], baseGear)); // Weapon group will be set later
         }
 
-//        // Update weapon groups for each CharacterClass
-//        for (CharacterClass character : charClassList) {
-//            List<Integer> group = weaponGroups.get(weaponCharacter.get(character.id));
-//            if (group != null) {
-//                character.weaponGroup = group.stream().mapToInt(Integer::intValue).toArray();
-//            }
-//        }
+        // Update weapon groups for each CharacterClass
+        for (CharacterClass character : charClassList) {
+            List<Integer> group = weaponGroups.get(weaponCharacter.get(character.id));
+            if (group != null) {
+                character.weaponGroup = group.stream().mapToInt(Integer::intValue).toArray();
+        }
+        }
     }
 
-    private static int updateValue(StringXML object, String tagName) {
+    private static int getMaxValue(StringXML object, String tagName) {
         return object.children.stream()
                 .filter(child -> child.name.equals(tagName))
                 .map(child -> child.children.stream()
@@ -220,7 +193,7 @@ public enum CharacterClass {
      * Gets the same weapon classes as requested.
      *
      * @param classId Id of one class sharing the same weapon.
-     * @return List of classes sharing same weapons.
+     * @return int[] of classes sharing same weapons.
      */
     public static int[] weaponClasses(int classId) {
         return WEAPON_CLASSES.get(classId);
@@ -256,5 +229,10 @@ public enum CharacterClass {
 
     public int getId() {
         return id;
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 }


### PR DESCRIPTION
Drop hardcoded classes and replace with parsing, which should accommodate changes to the character classes. CharacterClass is no longer an Enum. #35 #73
No further edits are needed.

Implemented previous Enum default toString behavior to the new CharacterClass to continue returning the name of the character class, instead of the java class.