### PR TITLE
fix: don't let a missing asset file kill the Loot tab

### DIFF
--- a/src/main/java/tomato/realmshark/ParseDungeon.java
+++ b/src/main/java/tomato/realmshark/ParseDungeon.java
@@ -1,6 +1,7 @@
 package tomato.realmshark;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -30,12 +31,43 @@ public class ParseDungeon {
      * Load Dungeon modifiers XML data to get names from file.
      */
     static {
-        parseDungeonModifier();
-        parseDungeonPortalId();
+        loadAssets();
+    }
+
+    /**
+     * Parses the XML assets this class needs.
+     *
+     * Nothing in here may propagate an exception. This runs from a static
+     * initializer, so a throw leaves the class permanently unusable for the
+     * rest of the JVM's life - every later reference fails with
+     * NoClassDefFoundError, which is how a single missing asset file took out
+     * the whole loot display. Assets are legitimately absent before extraction,
+     * so empty maps are a valid state: names simply resolve to nothing.
+     */
+    private static void loadAssets() {
+        try {
+            parseDungeonModifier();
+        } catch (Throwable t) {
+            System.out.println("[ParseDungeon] modifier parse failed: " + t);
+        }
+        try {
+            parseDungeonPortalId();
+        } catch (Throwable t) {
+            System.out.println("[ParseDungeon] portal parse failed: " + t);
+        }
     }
 
     private static void parseDungeonModifier() {
         for (String path : MODS_XML_PATHS) {
+            // The client does not ship every mods file in every build -
+            // mods2.xml is absent as of the current release. A missing
+            // supplementary file must not be fatal.
+            if (!new File(path).isFile()) {
+                System.out.println(
+                    "[ParseDungeon] " + path + " not present, skipping"
+                );
+                continue;
+            }
             try {
                 FileInputStream file = new FileInputStream(path);
                 String result = new BufferedReader(new InputStreamReader(file))
@@ -79,6 +111,14 @@ public class ParseDungeon {
     }
 
     private static void parseDungeonPortalId() {
+        // Absent on a fresh install until assets are extracted. Same treatment
+        // as the mods files: skip rather than throw.
+        if (!new File(PORTAL_XML_PATH).isFile()) {
+            System.out.println(
+                "[ParseDungeon] " + PORTAL_XML_PATH + " not present, skipping"
+            );
+            return;
+        }
         try {
             FileInputStream file = new FileInputStream(PORTAL_XML_PATH);
             String result = new BufferedReader(new InputStreamReader(file))


### PR DESCRIPTION
The client no longer ships assets/xml/mods2.xml - it was removed in a game update along with the other *2.xml files, which were a temporary split since merged back. mods2.xml is the only one referenced in code.

ParseDungeon treated it as mandatory and threw RuntimeException when absent. That throw happens in a static initializer, so the JVM marks the class permanently unusable and every later reference fails with NoClassDefFoundError for the rest of the session.

It surfaces from displayDungeonIcon, which runs before displayBagLootIcons and before the SendLoot call, so one missing file takes out the whole loot pipeline - the loot display and every loot-related ping.

    Exception in thread "Thread-1" java.lang.ExceptionInInitializerError
        at tomato.gui.stats.LootGUI.displayDungeonIcon(LootGUI.java:528)
    Caused by: java.lang.RuntimeException: java.io.FileNotFoundException:
        assets\xml\mods2.xml
        at tomato.realmshark.ParseDungeon.<clinit>(ParseDungeon.java:33)

It only triggers once assets are re-extracted, so anyone who answered "Ignore" to the extract prompt keeps a stale mods2.xml and stays working - which is why the same version breaks for one user and not another.

Missing mods files are now skipped, missing portals.xml likewise (absent on a fresh install before extraction), and asset parsing is wrapped so nothing can escape the initializer. Empty maps are a valid state - names resolve to nothing until assets exist.

Verified against three asset states. With every file present the result is unchanged (248 modifiers, 81 portals), so installs that were working stay byte-for-byte identical; the two states that previously crashed now load.