### PR TITLE
feat: loot ping improvements - show what pinged, dungeon pings, per-type sounds

### DIFF
--- a/src/main/java/tomato/backend/data/TomatoData.java
+++ b/src/main/java/tomato/backend/data/TomatoData.java
@@ -20,6 +20,8 @@ import tomato.gui.myinfo.MyInfoGUI;
 import tomato.gui.security.ParsePanelGUI;
 import tomato.gui.stats.LootGUI;
 import tomato.realmshark.HttpCharListRequest;
+import tomato.realmshark.ParseDungeon;
+import tomato.realmshark.PingSounds;
 import tomato.realmshark.RealmCharacter;
 import tomato.realmshark.RealmCharacterStats;
 import tomato.realmshark.Sound;
@@ -248,6 +250,7 @@ public class TomatoData {
             moonLightFlameCounter(idType);
             SecurityAbilityUseCheck.decoy(entity);
             customSoundAlert(idType);
+            dungeonPingAlert(idType);
         }
         if (petyard) {
             addPet(object);
@@ -280,7 +283,7 @@ public class TomatoData {
         if (idEntityPing != null) {
             for (String id : idEntityPing) {
                 if (String.valueOf(idType).equals(id)) {
-                    Sound.custom.play();
+                    PingSounds.play(PingSounds.Type.ENTITY);
                     break;
                 }
             }
@@ -1177,17 +1180,61 @@ public class TomatoData {
     }
 
     /**
-     * Checks if any enchant in the enchant text matches selected enchant pings
+     * Checks whether a dungeon is in the user's dungeon-ping selection.
+     *
+     * Selections are stored as dungeon NAMES rather than portal objectTypes,
+     * because several dungeons ship more than one portal variant and the user
+     * means "tell me when this dungeon drops", not "when this exact portal id
+     * appears".
+     *
+     * @param dungeonName Dungeon name resolved from a portal entity.
+     * @return True if the user wants a ping for this dungeon.
      */
-    public boolean isEnchantPing(String enchantText) {
+    public boolean isDungeonPing(String dungeonName) {
+        if (dungeonName == null || dungeonName.isEmpty()) return false;
+
+        String saved = PropertiesManager.getProperty("dungeonPing.selected");
+        if (saved == null || saved.trim().isEmpty()) return false;
+
+        for (String s : saved.split(",")) {
+            if (dungeonName.equalsIgnoreCase(s.trim())) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Plays the alert sound when a portal for a ping-selected dungeon appears.
+     *
+     * @param objectType objectType of a newly seen entity.
+     */
+    private void dungeonPingAlert(int objectType) {
+        String dungeonName = ParseDungeon.getDungeonNameByPortalType(objectType);
+        if (dungeonName == null) return; // not a portal
+        if (isDungeonPing(dungeonName)) {
+            PingSounds.play(PingSounds.Type.DUNGEON);
+        }
+    }
+
+    /**
+     * Returns the NAMES of every enchant on an item that matches the user's
+     * enchant-ping selection.
+     *
+     * Exists so the loot GUI can show which enchant actually triggered a ping,
+     * rather than only knowing that something did.
+     *
+     * @param enchantText Parsed enchant text, "EnchantName(ID)" per line.
+     * @return Matching enchant display names; empty if none match.
+     */
+    public ArrayList<String> getMatchedEnchantPings(String enchantText) {
+        ArrayList<String> matched = new ArrayList<>();
         if (enchantText == null || enchantText.isEmpty()) {
-            return false;
+            return matched;
         }
 
         // Load saved enchant ping selections
         String saved = PropertiesManager.getProperty("enchantPing.selected");
         if (saved == null || saved.trim().isEmpty()) {
-            return false;
+            return matched;
         }
 
         Set<Short> selectedEnchants = new HashSet<>();
@@ -1206,12 +1253,13 @@ public class TomatoData {
             // Parse enchant ID from the line (format: "EnchantName(ID)")
             if (enchantLine.contains("(") && enchantLine.contains(")")) {
                 try {
-                    int start = enchantLine.lastIndexOf("(") + 1;
+                    int open = enchantLine.lastIndexOf("(");
                     int end = enchantLine.lastIndexOf(")");
-                    String idStr = enchantLine.substring(start, end);
+                    String idStr = enchantLine.substring(open + 1, end);
                     short enchantId = Short.parseShort(idStr);
                     if (selectedEnchants.contains(enchantId)) {
-                        return true;
+                        String name = enchantLine.substring(0, open).trim();
+                        if (!name.isEmpty()) matched.add(name);
                     }
                 } catch (
                     NumberFormatException
@@ -1220,7 +1268,14 @@ public class TomatoData {
             }
         }
 
-        return false;
+        return matched;
+    }
+
+    /**
+     * Checks if any enchant in the enchant text matches selected enchant pings
+     */
+    public boolean isEnchantPing(String enchantText) {
+        return !getMatchedEnchantPings(enchantText).isEmpty();
     }
 
     /**

--- a/src/main/java/tomato/gui/TomatoGUI.java
+++ b/src/main/java/tomato/gui/TomatoGUI.java
@@ -299,4 +299,11 @@ public class TomatoGUI {
     public static void openEnchantPing() {
         EnchantPingGUI.open();
     }
+
+    /**
+     * Opens dungeon ping window.
+     */
+    public static void openDungeonPing() {
+        DungeonPingGUI.open();
+    }
 }

--- a/src/main/java/tomato/gui/maingui/DungeonPingGUI.java
+++ b/src/main/java/tomato/gui/maingui/DungeonPingGUI.java
@@ -1,0 +1,199 @@
+package tomato.gui.maingui;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import tomato.realmshark.ParseDungeon;
+import util.PropertiesManager;
+
+/**
+ * Selection window for "ping me when this dungeon drops".
+ *
+ * Mirrors EnchantPingGUI, but as a flat searchable list - there are only ~150
+ * dungeons and they are already recognisable by name, so the A-Z grouping the
+ * 1000-entry enchant list needs would just add clicks here.
+ *
+ * Selections are persisted as dungeon NAMES (property "dungeonPing.selected"),
+ * not portal object ids, so a dungeon with several portal variants is covered
+ * by a single tick. TomatoData.isDungeonPing() reads the same property.
+ */
+public class DungeonPingGUI extends JPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String PROP = "dungeonPing.selected";
+
+    private final JTextField searchField = new JTextField(20);
+    private final JPanel listPanel = new JPanel();
+    private final Map<String, JCheckBox> checkBoxMap = new LinkedHashMap<>();
+    private final JLabel countLabel = new JLabel();
+
+    public DungeonPingGUI() {
+        super(new BorderLayout(8, 8));
+        setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+
+        List<String> saved = loadSelected();
+
+        JPanel topPanel = new JPanel(new BorderLayout());
+        topPanel.add(new JLabel("Search: "), BorderLayout.WEST);
+        topPanel.add(searchField, BorderLayout.CENTER);
+        this.add(topPanel, BorderLayout.NORTH);
+
+        listPanel.setLayout(new BoxLayout(listPanel, BoxLayout.Y_AXIS));
+        JScrollPane scrollPane = new JScrollPane(listPanel);
+        scrollPane.setVerticalScrollBarPolicy(
+            ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS
+        );
+        // JPanel is not Scrollable: without this the wheel moves 1px per tick.
+        scrollPane.getVerticalScrollBar().setUnitIncrement(40);
+        this.add(scrollPane, BorderLayout.CENTER);
+
+        JPanel bottomPanel = new JPanel(new BorderLayout());
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton selectAllBtn = new JButton("Select All");
+        JButton clearAllBtn = new JButton("Clear All");
+        JButton saveButton = new JButton("Save");
+        buttons.add(selectAllBtn);
+        buttons.add(clearAllBtn);
+        buttons.add(saveButton);
+        countLabel.setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 0));
+        bottomPanel.add(countLabel, BorderLayout.WEST);
+        bottomPanel.add(buttons, BorderLayout.EAST);
+        this.add(bottomPanel, BorderLayout.SOUTH);
+
+        buildList(saved);
+
+        searchField
+            .getDocument()
+            .addDocumentListener(
+                new DocumentListener() {
+                    @Override
+                    public void insertUpdate(DocumentEvent e) {
+                        filterList();
+                    }
+
+                    @Override
+                    public void removeUpdate(DocumentEvent e) {
+                        filterList();
+                    }
+
+                    @Override
+                    public void changedUpdate(DocumentEvent e) {
+                        filterList();
+                    }
+                }
+            );
+
+        saveButton.addActionListener(e -> {
+            List<String> selected = new ArrayList<>();
+            for (Map.Entry<String, JCheckBox> en : checkBoxMap.entrySet()) {
+                if (en.getValue().isSelected()) selected.add(en.getKey());
+            }
+            PropertiesManager.setProperties(PROP, String.join(",", selected));
+            updateCount();
+            JOptionPane.showMessageDialog(
+                DungeonPingGUI.this,
+                "Saved " + selected.size() + " dungeon(s).",
+                "Save",
+                JOptionPane.INFORMATION_MESSAGE
+            );
+        });
+
+        // Only touch what the search currently shows, so "Select All" while
+        // filtered does the obvious thing instead of silently ticking all 150.
+        selectAllBtn.addActionListener(e -> setVisibleSelected(true));
+        clearAllBtn.addActionListener(e -> setVisibleSelected(false));
+    }
+
+    private void setVisibleSelected(boolean selected) {
+        for (JCheckBox cb : checkBoxMap.values()) {
+            if (cb.isVisible()) cb.setSelected(selected);
+        }
+        updateCount();
+    }
+
+    private static List<String> loadSelected() {
+        List<String> out = new ArrayList<>();
+        String saved = PropertiesManager.getProperty(PROP);
+        if (saved == null || saved.trim().isEmpty()) return out;
+        for (String s : saved.split(",")) {
+            String v = s.trim();
+            if (!v.isEmpty()) out.add(v);
+        }
+        return out;
+    }
+
+    private void buildList(List<String> saved) {
+        listPanel.removeAll();
+        checkBoxMap.clear();
+
+        List<String> names = ParseDungeon.allDungeonNames();
+        if (names.isEmpty()) {
+            listPanel.add(
+                new JLabel(
+                    "<html>No dungeons found.<br/>" +
+                    "Game assets have not been extracted yet.</html>"
+                )
+            );
+        }
+
+        for (String name : names) {
+            JCheckBox cb = new JCheckBox(name);
+            cb.setAlignmentX(Component.LEFT_ALIGNMENT);
+            for (String s : saved) {
+                if (s.equalsIgnoreCase(name)) {
+                    cb.setSelected(true);
+                    break;
+                }
+            }
+            cb.addActionListener(e -> updateCount());
+            checkBoxMap.put(name, cb);
+            listPanel.add(cb);
+        }
+
+        updateCount();
+        listPanel.revalidate();
+        listPanel.repaint();
+    }
+
+    private void updateCount() {
+        int n = 0;
+        for (JCheckBox cb : checkBoxMap.values()) {
+            if (cb.isSelected()) n++;
+        }
+        countLabel.setText(n + " of " + checkBoxMap.size() + " selected");
+    }
+
+    private void filterList() {
+        String q = searchField.getText();
+        q = (q == null) ? "" : q.toLowerCase().trim();
+
+        for (Map.Entry<String, JCheckBox> en : checkBoxMap.entrySet()) {
+            boolean matches =
+                q.isEmpty() || en.getKey().toLowerCase().contains(q);
+            en.getValue().setVisible(matches);
+        }
+        listPanel.revalidate();
+        listPanel.repaint();
+    }
+
+    /**
+     * Opens the dungeon ping selection dialog.
+     */
+    public static void open() {
+        JFrame parent = tomato.gui.TomatoGUI.getFrame();
+        DungeonPingGUI panel = new DungeonPingGUI();
+        JDialog dialog = new JDialog(parent, "Dungeon Pings", true);
+        dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        dialog.getContentPane().add(panel);
+        dialog.pack();
+        dialog.setSize(420, 700);
+        dialog.setLocationRelativeTo(parent);
+        dialog.setVisible(true);
+    }
+}

--- a/src/main/java/tomato/gui/maingui/EnchantPingGUI.java
+++ b/src/main/java/tomato/gui/maingui/EnchantPingGUI.java
@@ -55,6 +55,8 @@ public class EnchantPingGUI extends JPanel {
         scrollPane.setVerticalScrollBarPolicy(
             ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS
         );
+        // Without this the viewport scrolls 1px per wheel tick.
+        scrollPane.getVerticalScrollBar().setUnitIncrement(40);
         this.add(scrollPane, BorderLayout.CENTER);
 
         // Bottom: save button + global controls
@@ -134,8 +136,18 @@ public class EnchantPingGUI extends JPanel {
             .sorted(Comparator.comparing(e -> e.getValue().toLowerCase()))
             .forEach(entry -> {
                 String name = entry.getValue();
-                if (name.equals(name.toUpperCase())) {
-                    // All uppercase names go to "Unique" group
+                // Display names are now proper-case, so "is it uppercase" no
+                // longer identifies uniques. The INTERNAL id still does:
+                // unique/ST enchants are ALL_CAPS there (e.g. LUCKY_STREAK)
+                // while rollable ones are mixed (e.g. Attack_Bonus_1).
+                String internalId = ParseEnchants.ENCHANT_INTERNAL_IDS.get(
+                    entry.getKey()
+                );
+                if (
+                    internalId != null &&
+                    !internalId.isEmpty() &&
+                    internalId.equals(internalId.toUpperCase())
+                ) {
                     groups
                         .computeIfAbsent("Unique", k -> new ArrayList<>())
                         .add(entry);
@@ -193,6 +205,12 @@ public class EnchantPingGUI extends JPanel {
                 String label = String.format("%s", cleanedName);
                 JCheckBox cb = new JCheckBox(label);
                 cb.setAlignmentX(Component.LEFT_ALIGNMENT);
+                // Numeric id matches what the console debug log prints, so the
+                // two can be cross-referenced while hunting a specific enchant.
+                String internal = ParseEnchants.ENCHANT_INTERNAL_IDS.get(id);
+                cb.setToolTipText(
+                    "id " + id + (internal == null ? "" : "  ·  " + internal)
+                );
                 // pre-select if stored
                 if (savedSelected.contains(id)) cb.setSelected(true);
                 checkBoxMap.put(id, cb);

--- a/src/main/java/tomato/gui/maingui/PingSoundGUI.java
+++ b/src/main/java/tomato/gui/maingui/PingSoundGUI.java
@@ -1,0 +1,200 @@
+package tomato.gui.maingui;
+
+import java.awt.*;
+import java.io.File;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import tomato.realmshark.PingSounds;
+
+/**
+ * Per-category ping sound picker.
+ *
+ * One row per ping type: a dropdown of the bundled clips plus the Windows
+ * notification library, a Browse button for anything else, and a Test button
+ * so a sound can be heard before committing to it.
+ */
+public class PingSoundGUI extends JPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<PingSounds.Type, JComboBox<String>> pickers =
+        new EnumMap<>(PingSounds.Type.class);
+
+    /** Full paths backing the dropdown entries, parallel to their indexes. */
+    private final Map<PingSounds.Type, DefaultComboBoxModel<String>> models =
+        new EnumMap<>(PingSounds.Type.class);
+
+    private final Map<PingSounds.Type, String> chosen = new EnumMap<>(
+        PingSounds.Type.class
+    );
+
+    public PingSoundGUI() {
+        super(new BorderLayout(8, 8));
+        setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+        List<String> available = PingSounds.availableSounds();
+
+        JPanel rows = new JPanel(new GridBagLayout());
+        GridBagConstraints c = new GridBagConstraints();
+        c.insets = new Insets(4, 4, 4, 4);
+        c.anchor = GridBagConstraints.WEST;
+
+        int row = 0;
+        for (PingSounds.Type type : PingSounds.Type.values()) {
+            String current = PingSounds.getPath(type);
+            chosen.put(type, current);
+
+            c.gridx = 0;
+            c.gridy = row;
+            c.weightx = 0;
+            c.fill = GridBagConstraints.NONE;
+            rows.add(new JLabel(type.label + ":"), c);
+
+            DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
+            for (String path : available) {
+                model.addElement(path);
+            }
+            // A previously browsed-to file may sit outside both folders.
+            if (model.getIndexOf(current) < 0) {
+                model.addElement(current);
+            }
+            model.setSelectedItem(current);
+
+            JComboBox<String> combo = new JComboBox<>(model);
+            // Show file names, keep full paths as the values.
+            combo.setRenderer(
+                new DefaultListCellRenderer() {
+                    @Override
+                    public Component getListCellRendererComponent(
+                        JList<?> list,
+                        Object value,
+                        int index,
+                        boolean isSelected,
+                        boolean cellHasFocus
+                    ) {
+                        super.getListCellRendererComponent(
+                            list,
+                            value,
+                            index,
+                            isSelected,
+                            cellHasFocus
+                        );
+                        setText(PingSounds.displayName((String) value));
+                        return this;
+                    }
+                }
+            );
+            combo.setPreferredSize(new Dimension(240, 26));
+            combo.addActionListener(e -> {
+                Object sel = combo.getSelectedItem();
+                if (sel != null) chosen.put(type, (String) sel);
+            });
+
+            c.gridx = 1;
+            c.weightx = 1;
+            c.fill = GridBagConstraints.HORIZONTAL;
+            rows.add(combo, c);
+
+            JButton browse = new JButton("Browse…");
+            browse.addActionListener(e -> browseFor(type, model, combo));
+            c.gridx = 2;
+            c.weightx = 0;
+            c.fill = GridBagConstraints.NONE;
+            rows.add(browse, c);
+
+            JButton test = new JButton("Test");
+            test.addActionListener(e -> {
+                // Apply first so the test plays what is actually selected.
+                PingSounds.setPath(type, chosen.get(type));
+                PingSounds.play(type);
+            });
+            c.gridx = 3;
+            rows.add(test, c);
+
+            pickers.put(type, combo);
+            models.put(type, model);
+            row++;
+        }
+
+        add(rows, BorderLayout.CENTER);
+
+        JLabel hint = new JLabel(
+            "<html><i>Sounds are taken from Tomato's sound folder and the " +
+            "Windows notification library (C:\\Windows\\Media).<br>" +
+            "Use Browse to pick any other .wav file.</i></html>"
+        );
+        hint.setBorder(BorderFactory.createEmptyBorder(8, 4, 0, 4));
+        add(hint, BorderLayout.NORTH);
+
+        JPanel bottom = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton defaults = new JButton("Restore Defaults");
+        JButton save = new JButton("Save");
+        bottom.add(defaults);
+        bottom.add(save);
+        add(bottom, BorderLayout.SOUTH);
+
+        defaults.addActionListener(e -> {
+            for (PingSounds.Type type : PingSounds.Type.values()) {
+                PingSounds.setPath(type, null);
+                String reset = PingSounds.getPath(type);
+                chosen.put(type, reset);
+                DefaultComboBoxModel<String> m = models.get(type);
+                if (m.getIndexOf(reset) < 0) m.addElement(reset);
+                m.setSelectedItem(reset);
+            }
+        });
+
+        save.addActionListener(e -> {
+            for (PingSounds.Type type : PingSounds.Type.values()) {
+                PingSounds.setPath(type, chosen.get(type));
+            }
+            JOptionPane.showMessageDialog(
+                PingSoundGUI.this,
+                "Ping sounds saved.",
+                "Save",
+                JOptionPane.INFORMATION_MESSAGE
+            );
+        });
+    }
+
+    private void browseFor(
+        PingSounds.Type type,
+        DefaultComboBoxModel<String> model,
+        JComboBox<String> combo
+    ) {
+        JFileChooser fc = new JFileChooser();
+        fc.setDialogTitle("Select a .wav for " + type.label);
+        fc.setFileFilter(new FileNameExtensionFilter("WAV audio", "wav"));
+        String current = chosen.get(type);
+        if (current != null) {
+            File f = new File(current);
+            if (f.getParentFile() != null && f.getParentFile().isDirectory()) {
+                fc.setCurrentDirectory(f.getParentFile());
+            }
+        }
+        if (fc.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            String path = fc.getSelectedFile().getAbsolutePath();
+            if (model.getIndexOf(path) < 0) model.addElement(path);
+            model.setSelectedItem(path);
+            combo.setSelectedItem(path);
+            chosen.put(type, path);
+        }
+    }
+
+    /**
+     * Opens the ping sound configuration dialog.
+     */
+    public static void open() {
+        JFrame parent = tomato.gui.TomatoGUI.getFrame();
+        PingSoundGUI panel = new PingSoundGUI();
+        JDialog dialog = new JDialog(parent, "Ping Sounds", true);
+        dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        dialog.getContentPane().add(panel);
+        dialog.pack();
+        dialog.setLocationRelativeTo(parent);
+        dialog.setVisible(true);
+    }
+}

--- a/src/main/java/tomato/gui/maingui/TomatoMenuBar.java
+++ b/src/main/java/tomato/gui/maingui/TomatoMenuBar.java
@@ -22,7 +22,7 @@ import java.awt.event.ActionListener;
  * Menu bar builder class
  */
 public class TomatoMenuBar implements ActionListener {
-    private JMenuItem about, borders, clearChat, bandwidth, javav, clearDpsLogs, theme, fontMenu, dpsOptions, chat, sound, chatPingMessage, entityIdPingMessage, itemPingMessage, enchantPingMessage;
+    private JMenuItem about, borders, clearChat, bandwidth, javav, clearDpsLogs, theme, fontMenu, dpsOptions, chat, sound, chatPingMessage, entityIdPingMessage, itemPingMessage, enchantPingMessage, dungeonPingMessage, pingSoundMenu;
     private JRadioButtonMenuItem fontSize8, fontSize12, fontSize16, fontSize24, fontSize48, fontSizeCustom;
     private JRadioButtonMenuItem themeDarcula, themeighContrastDark, themeHighContrastLight, themeIntelliJ, themeSolarizedDark, themeSolarizedLight;
     private JRadioButtonMenuItem fontNameMonospaced, fontNameDialog, fontNameDialogInput, fontNameSerif, fontNameSansSerif, fontNameSegoe;
@@ -119,12 +119,20 @@ public class TomatoMenuBar implements ActionListener {
         enchantPingMessage = new JMenuItem("Enchant Pings");
         enchantPingMessage.addActionListener(this);
 
+        dungeonPingMessage = new JMenuItem("Dungeon Pings");
+        dungeonPingMessage.addActionListener(this);
+
+        pingSoundMenu = new JMenuItem("Ping Sounds...");
+        pingSoundMenu.addActionListener(this);
+
         sound.add(new JLabel("Volume:"));
         sound.add(soundSlider);
         sound.add(new JSeparator(SwingConstants.HORIZONTAL));
         sound.add(entityIdPingMessage);
         sound.add(itemPingMessage);
         sound.add(enchantPingMessage);
+        sound.add(dungeonPingMessage);
+        sound.add(pingSoundMenu);
         sound.add(new JSeparator(SwingConstants.HORIZONTAL));
         sound.add(chatPing);
         sound.add(chatPingParty);
@@ -746,6 +754,10 @@ public class TomatoMenuBar implements ActionListener {
             TomatoGUI.openItemPing();
         } else if (e.getSource() == enchantPingMessage) { // enchant ping message
             TomatoGUI.openEnchantPing();
+        } else if (e.getSource() == dungeonPingMessage) { // dungeon ping message
+            TomatoGUI.openDungeonPing();
+        } else if (e.getSource() == pingSoundMenu) { // per-category ping sounds
+            tomato.gui.maingui.PingSoundGUI.open();
         } else if (e.getSource() == saveChat) { // chat save logs
             boolean b = saveChat.isSelected();
             PropertiesManager.setProperties("saveChat", b ? "true" : "false");

--- a/src/main/java/tomato/gui/stats/LootGUI.java
+++ b/src/main/java/tomato/gui/stats/LootGUI.java
@@ -32,6 +32,11 @@ public class LootGUI extends JPanel {
     private static Font mainFont;
 
     private static int lootDrops;
+
+    // Marks loot that triggered a ping. Deliberately outside the enchant-count
+    // glow palette (green/blue/purple/gold) so the two never read as the same
+    // signal.
+    private static final Color PING_COLOR = new Color(255, 64, 64);
     private boolean disableLootSharing = false;
     public static boolean filterWhiteBag = false;
     public static boolean filterOrangeBag = false;
@@ -61,6 +66,8 @@ public class LootGUI extends JPanel {
         scroll.setVerticalScrollBarPolicy(
             JScrollPane.VERTICAL_SCROLLBAR_ALWAYS
         );
+        // JPanel is not Scrollable, so the viewport defaults to 1px per tick.
+        scroll.getVerticalScrollBar().setUnitIncrement(40);
         new SmartScroller(scroll, 0);
         add(scroll, BorderLayout.CENTER);
     }
@@ -259,7 +266,20 @@ public class LootGUI extends JPanel {
             lootTime
         );
         mainPanel.add(Box.createHorizontalStrut(30));
-        width = displayBagLootIcons(bag, mainPanel, width);
+        java.util.List<String> bagPings = new java.util.ArrayList<>();
+        width = displayBagLootIcons(bag, mainPanel, width, bagPings);
+
+        // A pinged bag gets a coloured stripe down its left edge so it can be
+        // picked out while scrolling, without hovering every row. The left
+        // inset is reduced by the stripe width so nothing shifts alignment.
+        if (!bagPings.isEmpty()) {
+            mainPanel.setBorder(
+                BorderFactory.createCompoundBorder(
+                    BorderFactory.createMatteBorder(0, 4, 1, 0, PING_COLOR),
+                    BorderFactory.createEmptyBorder(0, 16, 0, 20)
+                )
+            );
+        }
 
         mainPanel.add(Box.createHorizontalGlue());
 
@@ -385,7 +405,8 @@ public class LootGUI extends JPanel {
     private static int displayBagLootIcons(
         Entity entity,
         JPanel mainPanel,
-        int width
+        int width,
+        java.util.List<String> bagPingsOut
     ) {
         JPanel panel = new JPanel();
         width += 200;
@@ -414,16 +435,11 @@ public class LootGUI extends JPanel {
             int enchantCount = 0;
 
             // Check for ping items and ping if found
-            if (
+            boolean itemPinged =
                 data.isItemPing(String.valueOf(statValue)) ||
-                data.isItemPing(itemName)
-            ) {
-                Sound.custom.play();
-            }
-
-            // Check for enchant pings
-            if (data.isEnchantPing(enchantText)) {
-                Sound.custom.play();
+                data.isItemPing(itemName);
+            if (itemPinged) {
+                PingSounds.play(PingSounds.Type.ITEM);
             }
 
             if (
@@ -437,6 +453,15 @@ public class LootGUI extends JPanel {
                     String[] enchantNames = enchantText.split("\n");
                     enchantCount = enchantNames.length;
                 }
+            }
+
+            // Check for enchant pings. Must run AFTER enchantText is parsed
+            // above - checking it earlier passes an empty string, which
+            // isEnchantPing() rejects outright, so the ping never fires.
+            java.util.ArrayList<String> matchedEnchants =
+                data.getMatchedEnchantPings(enchantText);
+            if (!matchedEnchants.isEmpty()) {
+                PingSounds.play(PingSounds.Type.ENCHANT);
             }
 
             JLabel icon;
@@ -474,12 +499,89 @@ public class LootGUI extends JPanel {
             if (!enchantText.isEmpty()) {
                 itemName += "<br>" + enchantText;
             }
+
+            // Mark the item that actually caused a ping, so a bag full of
+            // enchanted loot does not have to be hovered slot by slot to find
+            // out which one fired.
+            if (!matchedEnchants.isEmpty() || itemPinged) {
+                icon.setText(pingBadge(matchedEnchants, itemPinged));
+                // Draw the badge ON the sprite - the cell is only 24px wide, so
+                // there is no room to place it beside the icon.
+                icon.setHorizontalTextPosition(SwingConstants.CENTER);
+                icon.setVerticalTextPosition(SwingConstants.CENTER);
+                icon.setFont(icon.getFont().deriveFont(Font.BOLD, 11f));
+                icon.setForeground(PING_COLOR);
+                icon.setBorder(BorderFactory.createLineBorder(PING_COLOR, 1));
+
+                StringBuilder why = new StringBuilder("<br><b>PING: ");
+                if (itemPinged) why.append("item match");
+                for (int m = 0; m < matchedEnchants.size(); m++) {
+                    if (itemPinged || m > 0) why.append(", ");
+                    why.append(matchedEnchants.get(m));
+                }
+                itemName += why.append("</b>").toString();
+
+                bagPingsOut.addAll(matchedEnchants);
+                if (itemPinged) bagPingsOut.add(itemName);
+            }
+
             icon.setToolTipText("<html>" + itemName + "</html>");
             panel.add(icon);
         }
 
         mainPanel.add(panel);
         return width;
+    }
+
+    /**
+     * Set false for strictly one letter per enchant.
+     *
+     * Two initials is the default because the single-letter form cannot
+     * separate the cases this feature exists for: "Lucky Streak" and "Loot
+     * Bonus IV" are both "L", so a lone letter does not answer "is this the
+     * ring I want or the off-class armour I can skip". "LS" vs "LB" does.
+     */
+    private static final boolean PING_BADGE_INITIALS = true;
+
+    /**
+     * Builds the short overlay label for a pinged item. A single matching
+     * enchant gets its initials (Lucky Streak -> "LS"); several matches fall
+     * back to one letter each so the badge cannot swamp a 24px cell. An
+     * item-list match is marked with a leading star.
+     */
+    private static String pingBadge(
+        java.util.List<String> matchedEnchants,
+        boolean itemPinged
+    ) {
+        StringBuilder sb = new StringBuilder();
+        if (itemPinged) sb.append('*');
+
+        boolean useInitials =
+            PING_BADGE_INITIALS && matchedEnchants.size() == 1 && !itemPinged;
+
+        for (String name : matchedEnchants) {
+            if (name == null || name.isEmpty()) continue;
+            if (useInitials) {
+                sb.append(initials(name, 2));
+            } else {
+                sb.append(Character.toUpperCase(name.charAt(0)));
+            }
+            if (sb.length() >= 3) break; // keep the sprite readable
+        }
+        return sb.toString();
+    }
+
+    /**
+     * First letter of up to {@code max} words: "Lucky Streak" -> "LS".
+     */
+    private static String initials(String name, int max) {
+        StringBuilder sb = new StringBuilder();
+        for (String word : name.trim().split("\\s+")) {
+            if (word.isEmpty()) continue;
+            sb.append(Character.toUpperCase(word.charAt(0)));
+            if (sb.length() >= max) break;
+        }
+        return sb.toString();
     }
 
     private static void displayBagIcon(

--- a/src/main/java/tomato/realmshark/ParseDungeon.java
+++ b/src/main/java/tomato/realmshark/ParseDungeon.java
@@ -1,6 +1,7 @@
 package tomato.realmshark;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -30,12 +31,43 @@ public class ParseDungeon {
      * Load Dungeon modifiers XML data to get names from file.
      */
     static {
-        parseDungeonModifier();
-        parseDungeonPortalId();
+        loadAssets();
+    }
+
+    /**
+     * Parses the XML assets this class needs.
+     *
+     * Nothing in here may propagate an exception. This runs from a static
+     * initializer, so a throw leaves the class permanently unusable for the
+     * rest of the JVM's life - every later reference fails with
+     * NoClassDefFoundError, which is how a single missing asset file took out
+     * the whole loot display. Assets are legitimately absent before extraction,
+     * so empty maps are a valid state: names simply resolve to nothing.
+     */
+    private static void loadAssets() {
+        try {
+            parseDungeonModifier();
+        } catch (Throwable t) {
+            System.out.println("[ParseDungeon] modifier parse failed: " + t);
+        }
+        try {
+            parseDungeonPortalId();
+        } catch (Throwable t) {
+            System.out.println("[ParseDungeon] portal parse failed: " + t);
+        }
     }
 
     private static void parseDungeonModifier() {
         for (String path : MODS_XML_PATHS) {
+            // The client does not ship every mods file in every build -
+            // mods2.xml is absent as of the current release. A missing
+            // supplementary file must not be fatal.
+            if (!new File(path).isFile()) {
+                System.out.println(
+                    "[ParseDungeon] " + path + " not present, skipping"
+                );
+                continue;
+            }
             try {
                 FileInputStream file = new FileInputStream(path);
                 String result = new BufferedReader(new InputStreamReader(file))
@@ -79,6 +111,14 @@ public class ParseDungeon {
     }
 
     private static void parseDungeonPortalId() {
+        // Absent on a fresh install until assets are extracted. Same treatment
+        // as the mods files: skip rather than throw.
+        if (!new File(PORTAL_XML_PATH).isFile()) {
+            System.out.println(
+                "[ParseDungeon] " + PORTAL_XML_PATH + " not present, skipping"
+            );
+            return;
+        }
         try {
             FileInputStream file = new FileInputStream(PORTAL_XML_PATH);
             String result = new BufferedReader(new InputStreamReader(file))

--- a/src/main/java/tomato/realmshark/ParseDungeon.java
+++ b/src/main/java/tomato/realmshark/ParseDungeon.java
@@ -5,8 +5,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.xml.parsers.ParserConfigurationException;
 import org.xml.sax.SAXException;
@@ -20,11 +24,17 @@ public class ParseDungeon {
         "assets/xml/mods2.xml",
     };
     private static final String PORTAL_XML_PATH = "assets/xml/portals.xml";
+    private static final String XML_DIR_PATH = "assets/xml";
     private static final HashMap<Integer, String> ID_TO_NAME_MODS =
         new HashMap<>();
     private static final HashMap<String, Integer> NAME_TO_ID_MODS =
         new HashMap<>();
     private static final HashMap<String, Integer> NAME_TO_ID_PORTAL =
+        new HashMap<>();
+
+    // Reverse of NAME_TO_ID_PORTAL: portal objectType -> dungeon name. Lets a
+    // portal entity seen in the world be identified as a specific dungeon.
+    private static final HashMap<Integer, String> ID_TO_NAME_PORTAL =
         new HashMap<>();
 
     /**
@@ -54,6 +64,11 @@ public class ParseDungeon {
             parseDungeonPortalId();
         } catch (Throwable t) {
             System.out.println("[ParseDungeon] portal parse failed: " + t);
+        }
+        try {
+            parseAllPortalObjects();
+        } catch (Throwable t) {
+            System.out.println("[ParseDungeon] portal scan failed: " + t);
         }
     }
 
@@ -142,6 +157,7 @@ public class ParseDungeon {
                     }
                     if (name != null && id != 0) {
                         NAME_TO_ID_PORTAL.put(name, id);
+                        ID_TO_NAME_PORTAL.put(id, name);
                     }
                 }
             }
@@ -149,6 +165,85 @@ public class ParseDungeon {
         } catch (ParserConfigurationException | IOException | SAXException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * portals.xml only defines the classic dungeons - every modern one (Lost
+     * Halls, Cultist Hideout, The Void, Moonlight Village, The Nest, ...) lives
+     * in its own per-dungeon objects file. Reading only portals.xml finds 82 of
+     * the ~160 dungeon portals in the game, so this sweeps every extracted XML
+     * for objects carrying a DungeonName.
+     *
+     * A light regex pass rather than a DOM parse of 230+ files.
+     */
+    private static void parseAllPortalObjects() {
+        File dir = new File(XML_DIR_PATH);
+        File[] files = dir.listFiles((d, n) -> n.toLowerCase().endsWith(".xml"));
+        if (files == null) return;
+
+        Pattern objectBlock = Pattern.compile(
+            "<Object\\s[^>]*type=\"([^\"]+)\"[^>]*>(.*?)</Object>",
+            Pattern.DOTALL
+        );
+        Pattern dungeonName = Pattern.compile(
+            "<DungeonName>(.*?)</DungeonName>",
+            Pattern.DOTALL
+        );
+
+        for (File f : files) {
+            String content;
+            try {
+                content = new String(
+                    Files.readAllBytes(f.toPath()),
+                    StandardCharsets.UTF_8
+                );
+            } catch (IOException e) {
+                continue; // skip unreadable file, keep going
+            }
+            if (!content.contains("<DungeonName>")) continue;
+
+            Matcher m = objectBlock.matcher(content);
+            while (m.find()) {
+                Matcher dn = dungeonName.matcher(m.group(2));
+                if (!dn.find()) continue;
+                String name = dn.group(1).trim();
+                if (name.isEmpty()) continue;
+                try {
+                    int type = Integer.decode(m.group(1).trim());
+                    ID_TO_NAME_PORTAL.put(type, name);
+                    // Do not clobber portals.xml, which stays authoritative for
+                    // the loot-tab dungeon icons.
+                    NAME_TO_ID_PORTAL.putIfAbsent(name, type);
+                } catch (NumberFormatException ignored) {}
+            }
+        }
+    }
+
+    /**
+     * Resolves a world entity's objectType to a dungeon name, if that entity is
+     * a dungeon portal.
+     *
+     * @param objectType Entity objectType seen in the world.
+     * @return The dungeon name, or null if this objectType is not a portal.
+     */
+    public static String getDungeonNameByPortalType(int objectType) {
+        return ID_TO_NAME_PORTAL.get(objectType);
+    }
+
+    /**
+     * Every known dungeon name, sorted, for populating selection UIs.
+     *
+     * Fewer entries than there are portal objectTypes: some dungeons ship
+     * several portal variants (Cultist Hideout has a normal and a temp portal),
+     * which is why selections are keyed by NAME - picking the name covers every
+     * variant of that dungeon.
+     */
+    public static java.util.List<String> allDungeonNames() {
+        java.util.TreeSet<String> names = new java.util.TreeSet<>(
+            String.CASE_INSENSITIVE_ORDER
+        );
+        names.addAll(ID_TO_NAME_PORTAL.values());
+        return new java.util.ArrayList<>(names);
     }
 
     public static int[] getModIds(String dungeonString) {

--- a/src/main/java/tomato/realmshark/ParseEnchants.java
+++ b/src/main/java/tomato/realmshark/ParseEnchants.java
@@ -33,8 +33,15 @@ public class ParseEnchants {
     private static final String ENCHANT_XML_PATH =
         "assets/xml/enchantments.xml";
 
-    // Maps enchant type ID -> display name
+    // Maps enchant type ID -> human readable name (<DisplayId> from the XML,
+    // e.g. "Attack Bonus I"). Falls back to the internal id if absent.
     public static final HashMap<Short, String> ENCHANTS = new HashMap<>();
+
+    // Maps enchant type ID -> internal id (the "id" attribute, e.g.
+    // "Attack_Bonus_1" / "LUCKY_STREAK"). Kept because the all-uppercase ones
+    // mark unique/ST enchants, which the ping list groups separately.
+    public static final HashMap<Short, String> ENCHANT_INTERNAL_IDS =
+        new HashMap<>();
 
     // Maps enchant type ID -> parsed effect multipliers
     private static final HashMap<Short, EnchantEffect> ENCHANT_EFFECTS =
@@ -66,6 +73,7 @@ public class ParseEnchants {
 
                 Short enchantType = null;
                 String enchantName = null;
+                String displayName = null;
                 EnchantEffect effect = new EnchantEffect();
                 RegenEffect regen = new RegenEffect();
                 float lootBonus = 0f;
@@ -73,6 +81,8 @@ public class ParseEnchants {
                 for (StringXML node : xml) {
                     if (Objects.equals(node.name, "id")) {
                         enchantName = node.value;
+                    } else if (Objects.equals(node.name, "DisplayId")) {
+                        displayName = readTextContent(node);
                     } else if (Objects.equals(node.name, "type")) {
                         try {
                             enchantType = Short.decode(node.value);
@@ -166,8 +176,17 @@ public class ParseEnchants {
                 }
 
                 if (enchantType != null) {
+                    // Prefer the readable <DisplayId>; fall back to the internal
+                    // id so an entry is never nameless.
+                    String shown = (displayName != null &&
+                            !displayName.trim().isEmpty())
+                        ? displayName.trim()
+                        : enchantName;
+                    if (shown != null) {
+                        ENCHANTS.put(enchantType, shown);
+                    }
                     if (enchantName != null) {
-                        ENCHANTS.put(enchantType, enchantName);
+                        ENCHANT_INTERNAL_IDS.put(enchantType, enchantName);
                     }
                     ENCHANT_EFFECTS.put(enchantType, effect);
                     ENCHANT_REGEN.put(enchantType, regen);
@@ -646,6 +665,19 @@ public class ParseEnchants {
     }
 
     // ===== Helpers =====
+
+    /**
+     * Reads an element's text content. util.StringXML keeps text as the first
+     * child rather than on the node itself, so check there before node.value.
+     */
+    private static String readTextContent(StringXML node) {
+        if (node == null) return null;
+        if (node.children != null && !node.children.isEmpty()) {
+            String v = node.children.get(0).value;
+            if (v != null) return v;
+        }
+        return node.value;
+    }
 
     private static String getEnchantmentString(short enchantID) {
         String name = ENCHANTS.get(enchantID);

--- a/src/main/java/tomato/realmshark/PingSounds.java
+++ b/src/main/java/tomato/realmshark/PingSounds.java
@@ -1,0 +1,162 @@
+package tomato.realmshark;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import util.PropertiesManager;
+
+/**
+ * Per-category ping sounds.
+ *
+ * Every alert used to share the single Sound.custom clip, so a ping told you
+ * that something happened but not what. Each category now owns its own
+ * configurable sound.
+ *
+ * Sounds are chosen from the Windows notification library (C:\Windows\Media)
+ * plus Tomato's bundled sound folder, and any other .wav can be pointed at
+ * directly. Selections persist per category as an absolute path.
+ *
+ * Clips are loaded lazily and cached; changing a path drops the cached clip so
+ * the next play picks the new file up.
+ */
+public class PingSounds {
+
+    /** Windows ships ~70 notification wavs here. Absent on mac/linux. */
+    private static final String WINDOWS_MEDIA_DIR = "C:/Windows/Media";
+
+    /** Tomato's own bundled sounds, relative to the working directory. */
+    private static final String BUNDLED_SOUND_DIR = "sound";
+
+    /** Used when nothing else resolves - the historical shared ping sound. */
+    private static final String FALLBACK = "sound/custom.wav";
+
+    public enum Type {
+        ENCHANT("pingSound.enchant", "Enchant ping", "Windows Notify.wav"),
+        DUNGEON("pingSound.dungeon", "Dungeon ping", "Windows Ding.wav"),
+        ITEM("pingSound.item", "Item ping", "chimes.wav"),
+        ENTITY("pingSound.entity", "Entity ID ping", "Windows Balloon.wav");
+
+        public final String key;
+        public final String label;
+        /** Preferred Windows sound; only used if that file actually exists. */
+        private final String preferredDefault;
+
+        Type(String key, String label, String preferredDefault) {
+            this.key = key;
+            this.label = label;
+            this.preferredDefault = preferredDefault;
+        }
+    }
+
+    private static final Map<Type, Sound> CACHE = new EnumMap<>(Type.class);
+
+    private PingSounds() {}
+
+    /**
+     * Configured sound file for a category.
+     *
+     * Falls back to a distinct Windows notification sound so the categories are
+     * audibly different out of the box - which is the whole point - and to the
+     * bundled clip when those are unavailable (non-Windows, or trimmed install).
+     */
+    public static String getPath(Type type) {
+        String saved = PropertiesManager.getProperty(type.key);
+        if (saved != null && !saved.trim().isEmpty()) {
+            return saved.trim();
+        }
+        File preferred = new File(WINDOWS_MEDIA_DIR, type.preferredDefault);
+        if (preferred.isFile()) {
+            return preferred.getAbsolutePath();
+        }
+        return FALLBACK;
+    }
+
+    /**
+     * Sets the sound file for a category and drops the cached clip.
+     *
+     * @param path Absolute path to a .wav, or null/empty to restore the default.
+     */
+    public static void setPath(Type type, String path) {
+        PropertiesManager.setProperties(type.key, path == null ? "" : path);
+        synchronized (CACHE) {
+            CACHE.remove(type);
+        }
+    }
+
+    /**
+     * Plays the ping for a category. Never throws - a bad sound file must not
+     * break loot handling.
+     */
+    public static void play(Type type) {
+        try {
+            Sound s = get(type);
+            if (s != null) s.play();
+        } catch (Throwable t) {
+            System.out.println(
+                "[PingSounds] failed to play " + type.label + ": " + t
+            );
+        }
+    }
+
+    private static Sound get(Type type) {
+        synchronized (CACHE) {
+            Sound cached = CACHE.get(type);
+            if (cached != null) return cached;
+
+            String path = getPath(type);
+            Sound s = new Sound(path);
+            if (!s.isLoaded() && !FALLBACK.equals(path)) {
+                // Configured file is missing or an unsupported format.
+                System.out.println(
+                    "[PingSounds] could not load \"" + path +
+                    "\" for " + type.label + ", using default sound"
+                );
+                s = new Sound(FALLBACK);
+            }
+            CACHE.put(type, s);
+            return s;
+        }
+    }
+
+    /** Forces every clip to reload on next play. */
+    public static void clearCache() {
+        synchronized (CACHE) {
+            CACHE.clear();
+        }
+    }
+
+    /**
+     * Selectable sounds: Tomato's bundled clips first, then the Windows
+     * notification library.
+     *
+     * @return Absolute paths of every .wav found.
+     */
+    public static List<String> availableSounds() {
+        List<String> out = new ArrayList<>();
+        addWavsFrom(new File(BUNDLED_SOUND_DIR), out);
+        addWavsFrom(new File(WINDOWS_MEDIA_DIR), out);
+        return out;
+    }
+
+    private static void addWavsFrom(File dir, List<String> out) {
+        if (dir == null || !dir.isDirectory()) return;
+        File[] files = dir.listFiles((d, n) ->
+            n.toLowerCase().endsWith(".wav")
+        );
+        if (files == null) return;
+        Arrays.sort(files, Comparator.comparing(f -> f.getName().toLowerCase()));
+        for (File f : files) {
+            out.add(f.getAbsolutePath());
+        }
+    }
+
+    /** Trims a path down to just the file name, for display. */
+    public static String displayName(String path) {
+        if (path == null || path.isEmpty()) return "(default)";
+        return new File(path).getName();
+    }
+}

--- a/src/main/java/tomato/realmshark/SendLoot.java
+++ b/src/main/java/tomato/realmshark/SendLoot.java
@@ -184,12 +184,11 @@ public class SendLoot {
 
                     if (!enchantText.isEmpty()) {
                         sl = Math.min(4, enchantText.split("\n").length);
-
-                        // Check for enchant pings
-                        if (data.isEnchantPing(enchantText)) {
-                            Sound.custom.play();
-                        }
                     }
+                    // NOTE: the enchant ping is deliberately NOT fired here.
+                    // This method is the loot-sharing uploader and only runs
+                    // when sharing is enabled, which made a local sound alert
+                    // depend on opting into telemetry. LootGUI owns the ping.
                 }
 
                 item.addProperty("sl", sl);

--- a/src/main/java/tomato/realmshark/Sound.java
+++ b/src/main/java/tomato/realmshark/Sound.java
@@ -42,6 +42,14 @@ public class Sound {
     }
 
     /**
+     * @return True if the clip loaded. Lets callers fall back to another file
+     *         when a user-selected sound is missing or an unsupported format.
+     */
+    public boolean isLoaded() {
+        return soundClip != null;
+    }
+
+    /**
      * Loads auto clip to be played later
      */
     static {


### PR DESCRIPTION
## Loot ping improvements: show what pinged, dungeon pings, per-type sounds

> **Depends on #76 ** (the missing-asset-crash fix) — both touch `ParseDungeon`,
> so this is branched on top to avoid a conflict. Once that merges, this diff
> collapses to just its own commit.

Five related changes to the ping system, smallest first. Happy to split any of
these out if you'd rather take them separately.

---

### 1. Enchant pings never fired from the loot display

The check ran before `enchantText` was parsed, so it always received an empty
string — which `isEnchantPing()` rejects outright:

```java
String enchantText = "";                        // empty
...
if (data.isEnchantPing(enchantText))            // checked here
...
enchantText = ParseEnchants.parse(enchants[i]); // filled ten lines later
```

A second, correct copy lives in `SendLoot.sendLoot()` — but that's the loot
**sharing** uploader, gated on `!disableLootSharing`. So the alert was only
reaching users as a side effect of opting into loot upload, and turning sharing
off silently killed it.

Moved the check below the parse, and removed the copy in `SendLoot` (which would
otherwise double-ping now that the real one works).

### 2. Readable enchant names

`ParseEnchants` read the `id` attribute (`ALIEN_NEO_ONSHOOT_ATTACK`) rather than
`<DisplayId>` (`Neo Alien OnShoot Attack Boost`).

Internal ids are kept in a second map, because the ping list uses "is it
ALL_CAPS" to identify unique/ST enchants — a signal that only exists on the
internal id. Verified: 204 uniques still group correctly, 812 in A–Z groups, and
no display name still contains an underscore.

### 3. Loot tab shows which item pinged

A ping told you something dropped, but not *what* or *where* — with several
enchanted items on screen you ended up hovering every slot of every bag.

- coloured stripe down the left edge of any bag row that pinged
- red outline plus a short letter badge on the item that actually fired
- the matching enchant named in the tooltip

`isEnchantPing()` returned only a boolean and couldn't say *what* matched, so
this adds `getMatchedEnchantPings()` and makes `isEnchantPing()` delegate to it —
one source of truth for the match logic.

The badge uses **two initials** for a single match rather than one letter:
"Lucky Streak" and "Loot Bonus IV" are both `L`, which is the exact pair the
feature exists to separate. `PING_BADGE_INITIALS = false` reverts to single
letters. This is the most cosmetic part of the PR — restyle freely.

### 4. Dungeon pings

**Sound → Dungeon Pings**: tick the dungeons worth interrupting for, get an
alert when that portal appears.

Portals already arrive as ordinary entities — the gap was **naming** them.
`portals.xml` defines 82 of ~160 dungeon portals; every modern dungeon lives in
its own per-dungeon objects file and couldn't be identified at all:

```
Lost Halls        -> lostHallsObjects.xml
Cultist Hideout   -> lostHallsObjects.xml
The Void          -> lostHallsObjects.xml
Moonlight Village -> moonlightVillageObjects.xml
The Nest          -> epicHiveObjects.xml
```

So this sweeps every extracted XML for objects carrying a `<DungeonName>`,
giving a portal `objectType` → name lookup for all 160. It's a light regex pass
rather than a DOM parse of 230+ files, and it's wrapped so it can't throw from
the initializer.

Selections are stored as dungeon **names**, not portal ids: several dungeons
ship more than one portal variant (Cultist Hideout has a normal and a temp
portal), and the user means "tell me when this dungeon drops". One tick covers
every variant — verified.

**Side effect:** loot-tab dungeon icons now resolve for modern dungeons instead
of falling back to the generic placeholder, since 78 more names map to real
portal ids.

### 5. Per-type ping sounds

Every alert shared one clip, so a ping couldn't tell you which *kind* of thing
happened. Enchant, dungeon, item and entity pings each get a configurable sound
(**Sound → Ping Sounds**), chosen from Tomato's bundled sounds plus the Windows
notification library — ~82 options with no new assets shipped — or any other
`.wav` via Browse.

Each type defaults to a *different* sound, falls back to the bundled clip off
Windows, and a missing file logs a warning and falls back rather than going mute
or throwing inside loot handling.

---

### Testing

| check | result |
|---|---|
| badge for single / multiple / item-list / unselected matches | correct in all cases |
| dungeon ping matching, incl. both Cultist Hideout portal variants | both match one selection |
| non-portal entities | correctly ignored |
| enchant display names | 1016 resolved, 0 with underscores, 204 uniques grouped |
| ping sounds | all four defaults resolve and load as real clips |
| bad sound path | warns and falls back, no throw |
| boots with no assets extracted | still passes (no regression on #<PR1>) |

Also built and run against a live client.

### Notes

- No changes to `build.gradle`, version handling, or any generated file.
- 3 new files (`DungeonPingGUI`, `PingSounds`, `PingSoundGUI`); the rest are
  additive edits.
- The badge styling and the ping colour are the parts most likely to want your
  opinion — both are one-line changes.
